### PR TITLE
chore: Zenodo concept DOI in CITATION.cff, SHA-pin setup-uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      # SHA-pinned like every other third-party action. This is the commit v5
+      # resolved to on the run that first went green; Dependabot proposes
+      # upgrades as normal PRs.
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       # Plain pip resolves the newest wheels even on the 3.9 leg, which is how
       # a false `pandas>=1.5` floor survived. Install exactly what the metadata
       # declares instead.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,12 +16,12 @@ date-released: "2026-08-01"
 license: MIT
 repository-code: "https://github.com/PhilanthroPy-Project/PhilanthroPy"
 url: "https://PhilanthroPy-Project.github.io/PhilanthroPy/"
-# Zenodo concept DOI — resolves to the latest deposited release. Replace the
-# placeholder with the real value after the first Zenodo deposit (see the
-# RELEASE CHECKLIST in CONTRIBUTING.md); JOSS requires it at acceptance.
+# Zenodo concept DOI — always resolves to the latest deposited release. This is
+# deliberately NOT the per-version DOI (v0.6.0 is 10.5281/zenodo.21751097); the
+# concept DOI is the one to cite so the reference does not go stale.
 identifiers:
   - type: doi
-    value: "10.5281/zenodo.PENDING"
+    value: "10.5281/zenodo.21751096"
     description: "Concept DOI for all versions of PhilanthroPy"
 keywords:
   - nonprofit


### PR DESCRIPTION
Follow-ups to the 0.6.0 release.

- **Zenodo.** The 0.6.0 release was archived as record `21751097`. That is the *per-version* DOI. `CITATION.cff` now carries the **concept** DOI `10.5281/zenodo.21751096`, which always resolves to the latest deposit, so the citation does not go stale at 0.7.0. JOSS requires a deposited archive with a DOI at acceptance.
- **Supply chain.** `astral-sh/setup-uv` was the last third-party action on a mutable tag; pinned to the commit `v5` resolved to on the run that first went green. `github/codeql-action` stays on `@v3`, matching the `actions/*` first-party tier.

Closes the last two items from the 0.6.0 hand-off that were mine to do.