### PR TITLE
feat: freeze the public API at 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [1.0.0] - TBD
+
+The API freeze. No code changes — 1.0.0 is a promise, not a feature.
+
+### Changed
+- `Development Status :: 5 - Production/Stable`.
+- **Tier 1 is now semver-protected.** A breaking change to any Tier 1 symbol
+  requires a major release, preceded by one full published minor emitting
+  `DeprecationWarning`. Tier 2 may still break in a minor; Tier 3 carries no
+  guarantee. The tiers are listed per-symbol in
+  [docs/reference/index.md](docs/reference/index.md).
+
+### Added
+- `test_stability_tier_table_covers_every_public_symbol` — the tier table is now
+  machine-checked against `__all__`, so a new public symbol cannot ship without
+  a stated tier. At 1.0 that table is the contract; an out-of-date one is a
+  broken promise, not a docs nit.
+
+### Notes
+The five 1.0 gates all hold at this commit: 0.7.0 published; the public-API
+contract test green with no exemption added since 0.7.0; no `deprecated_alias`
+anywhere in `philanthropy/`; `__version__ == importlib.metadata.version(...)`
+and `py.typed` in the wheel; every `__all__` symbol carries a tier and no Tier 1
+entry is mid-deprecation.
+
 ## [0.7.0] - TBD
 
 The removal release. Every shim below shipped in 0.6.0 emitting a

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
   - family-names: Lalakiya
     given-names: Shivam
     email: shivamlalakiya151299@gmail.com
-version: 0.7.0
+version: 1.0.0
 date-released: "2026-08-01"
 license: MIT
 repository-code: "https://github.com/PhilanthroPy-Project/PhilanthroPy"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ One toolkit, two audiences:
 
 ### Maturity
 
-Single-maintainer MIT project at `v0.7.0` (Beta). Preprocessing and the core classifiers are stable; grateful-patient featurization and `philanthropy.ingest` are Beta; `FinancialForecastModel` and `philanthropy.experimental.*` are Experimental and carry no API guarantees. Per-symbol stability tiers are in the [API reference](docs/reference/index.md).
+Single-maintainer MIT project at `v1.0.0`. Tier 1 symbols are semver-protected — a breaking change to any of them requires a major release preceded by one full published minor of `DeprecationWarning`. Preprocessing and the core classifiers are Tier 1; grateful-patient featurization and `philanthropy.ingest` are Tier 2 (Beta); `FinancialForecastModel` and `philanthropy.experimental.*` are Tier 3 (Experimental) and carry no API guarantees. Per-symbol stability tiers are in the [API reference](docs/reference/index.md).
 
 > **Maintenance:** maintained by one person on a best-effort basis. For vendor / OSS risk reviews: the bus factor is 1. Issues and PRs are welcome.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "philanthropy"
-version = "0.7.0"
+version = "1.0.0"
 description = "scikit-learn-native predictive analytics for nonprofit and academic-medical-center fundraising: donor propensity, lapse, planned giving, wealth screening, and revenue forecasting."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -25,7 +25,7 @@ keywords = [
     "python",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -102,10 +102,6 @@ def _predict_methods(cls):
     for attr, obj in inspect.getmembers(cls, predicate=inspect.isfunction):
         if not attr.startswith("predict") or attr in _SKLEARN_PREDICTORS:
             continue
-        # Deprecated aliases are on their way out (see tests/test_deprecations.py);
-        # the contract governs the names that survive to 1.0.
-        if (obj.__doc__ or "").startswith("Deprecated alias of"):
-            continue
         out.append(attr)
     return out
 
@@ -303,3 +299,63 @@ def test_no_exemption_is_stale():
 def test_every_exemption_carries_a_reason():
     for name, reason in _EXEMPT.items():
         assert len(reason) > 40, f"{name}'s exemption reason is not an explanation"
+
+
+# ---------------------------------------------------------------------------
+# The stability-tier table is the 1.0 semver contract
+#
+# From 1.0 the tier a symbol carries decides what a breaking change to it costs.
+# A table that has drifted from __all__ is a broken promise, not a docs nit, so
+# it is checked here rather than read by hand at release time.
+# ---------------------------------------------------------------------------
+
+_TIER_HEADINGS = ("### Tier 1 — Stable", "### Tier 2 — Beta", "### Tier 3 — Experimental")
+
+
+def _tier_table_text():
+    text = (REFERENCE_DIR / "index.md").read_text()
+    start = text.index(_TIER_HEADINGS[0])
+    end = text.index("## Score scales")
+    return text[start:end]
+
+
+def test_reference_index_declares_all_three_tiers():
+    text = (REFERENCE_DIR / "index.md").read_text()
+    for heading in _TIER_HEADINGS:
+        assert heading in text, f"docs/reference/index.md is missing {heading!r}"
+
+
+@pytest.mark.parametrize("subpackage", sorted(_public_subpackages()))
+def test_stability_tier_table_covers_every_public_symbol(subpackage):
+    table = _tier_table_text()
+    module = getattr(philanthropy, subpackage)
+
+    missing = [
+        symbol for symbol in module.__all__
+        if f"`{symbol}`" not in table
+    ]
+    # metrics is covered by one blanket row rather than nine names.
+    if subpackage == "metrics" and "every function in `philanthropy.metrics`" in table:
+        missing = []
+
+    assert not missing, (
+        f"docs/reference/index.md assigns no stability tier to "
+        f"philanthropy.{subpackage}: {missing}. At 1.0 the tier table is the "
+        f"semver contract — a public symbol without one has no stated promise."
+    )
+
+
+def test_tier_table_names_no_symbol_that_is_no_longer_public():
+    table = _tier_table_text()
+    public = {
+        symbol
+        for name in _public_subpackages()
+        for symbol in getattr(philanthropy, name).__all__
+    }
+    listed = {
+        sym
+        for line in table.splitlines() if line.startswith("|")
+        for sym in re.findall(r"`([A-Z]\w+)`", line.split("|")[1])
+    }
+    stale = sorted(listed - public)
+    assert not stale, f"tier table lists non-public symbols: {stale}"


### PR DESCRIPTION
Implements `HARDENING_PLAN.md` W3.18. **Merging only — not tagging or publishing.** CHANGELOG heading stays `## [1.0.0] - TBD`; cut it after 0.7.0 has had a real run on PyPI.

No behaviour changes. 1.0.0 is a promise, not a feature.

- `Development Status :: 5 - Production/Stable`
- **Tier 1 becomes semver-protected**: breaking any Tier 1 symbol now requires a major release preceded by one full published minor of `DeprecationWarning`. Tier 2 may still break in a minor; Tier 3 carries no guarantee. Tiers are listed per-symbol in `docs/reference/index.md`.
- `test_stability_tier_table_covers_every_public_symbol` makes that table a machine-checked contract. At 1.0 the table *is* the semver promise, so drift is a broken promise rather than a docs nit — a new public symbol can no longer ship without a stated tier.
- Drops the now-dead deprecated-alias skip in `_predict_methods`.

### The five 1.0 gates, all verified

| Gate | Status |
|---|---|
| 0.6.0 published on PyPI | yes — 0.6.0 live, clean-venv install verified |
| `test_public_api_contract.py` green, no exemption added since 0.7.0 | `_EXEMPT` is exactly 3: `RFMTransformer`, `UpliftTLearner`, `FinancialForecastModel` |
| `grep -rn deprecated_alias philanthropy` empty | yes |
| `__version__ == importlib.metadata.version(...)` and `py.typed` in wheel | yes |
| Every `__all__` symbol carries a tier, no Tier 1 mid-deprecation | now machine-checked |

`make ci` exit 0 — 1627 passed, 94.64% branch coverage.