### PR TITLE
chore(deps): bump five GitHub Actions to current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Lint and type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -46,7 +46,7 @@ jobs:
           - os: macos-latest
             python-version: "3.12"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -81,11 +81,11 @@ jobs:
     name: Declared dependency floors (lowest-direct)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # SHA-pinned like every other third-party action. This is the commit v5
       # resolved to on the run that first went green; Dependabot proposes
       # upgrades as normal PRs.
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       # Plain pip resolves the newest wheels even on the 3.9 leg, which is how
       # a false `pandas>=1.5` floor survived. Install exactly what the metadata
       # declares instead.
@@ -100,7 +100,7 @@ jobs:
     name: Build and check distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -117,7 +117,7 @@ jobs:
     name: Minimal install (no viz extra)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -35,7 +35,7 @@ jobs:
         mkdocs build --strict
 
     - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: site
 

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build JOSS paper draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # SHA-pinned: upstream publishes no tags, so `@master` is a mutable
       # third-party branch. Dependabot keeps this pin current.
@@ -30,7 +30,7 @@ jobs:
           paper-path: paper/paper.md
 
       - name: Upload paper.pdf
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: paper
           path: paper/paper.pdf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade twine
           python -m twine check dist/*
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -62,7 +62,7 @@ jobs:
       id-token: write   # REQUIRED for OIDC trusted publishing
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Consolidates Dependabot #9–#13. The ruleset sets `strict_required_status_checks_policy`, so merging five separate PRs means five rebase-and-revalidate cycles for one edit per line.

| Action | From | To | Exercised by PR CI? |
|---|---|---|---|
| `actions/checkout` | v4 | v7 | **Yes** — every job |
| `astral-sh/setup-uv` | v5 | v9.0.0 (SHA) | **Yes** — floors job |
| `actions/upload-pages-artifact` | v3 | v5 | Build half only; `deploy` runs on push to main |
| `actions/upload-artifact` | v4 | v7 | **No** |
| `actions/download-artifact` | v4 | v8 | **No** |

### The one thing worth knowing

`upload-artifact` and `download-artifact` are a **matched pair** in `publish.yml` — the build job uploads `dist/`, the publish job downloads it. `download-artifact@v8`'s own README pairs itself with `upload-artifact@v7`, so they have to move together; splitting them across PRs would leave main on a mismatched combination.

Neither is exercised by PR CI, because `publish.yml` only fires on a published release. **The first 0.7.0 release attempt is their real test.** That failure mode is safe — it aborts before the PyPI upload step, and PyPI never sees a partial release.

`actions/*` stay on tags (first-party tier); `setup-uv` keeps a SHA pin. Merging this closes #9–#13.