### PR TITLE
docs: distinguish the released version from what main carries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ One toolkit, two audiences:
 
 ### Maturity
 
-Single-maintainer MIT project at `v1.0.0`. Tier 1 symbols are semver-protected — a breaking change to any of them requires a major release preceded by one full published minor of `DeprecationWarning`. Preprocessing and the core classifiers are Tier 1; grateful-patient featurization and `philanthropy.ingest` are Tier 2 (Beta); `FinancialForecastModel` and `philanthropy.experimental.*` are Tier 3 (Experimental) and carry no API guarantees. Per-symbol stability tiers are in the [API reference](docs/reference/index.md).
+Single-maintainer MIT project. **`pip install philanthropy` gives you `0.6.0`**, the current release.
+
+`main` is ahead of it: `0.7.0` (removes the `0.6.0` deprecations) and `1.0.0` (freezes the API) are merged and green but deliberately unreleased, so the `0.6.0` deprecation warnings get a real migration window rather than a token one. Read the [CHANGELOG](CHANGELOG.md) for what is queued.
+
+Preprocessing and the core classifiers are Tier 1; grateful-patient featurization and `philanthropy.ingest` are Tier 2 (Beta); `FinancialForecastModel` and `philanthropy.experimental.*` are Tier 3 (Experimental) and carry no API guarantees. From `1.0.0`, Tier 1 becomes semver-protected — breaking one requires a major release preceded by a full published minor of `DeprecationWarning`. Per-symbol tiers are in the [API reference](docs/reference/index.md).
 
 > **Maintenance:** maintained by one person on a best-effort basis. For vendor / OSS risk reviews: the bus factor is 1. Issues and PRs are welcome.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,12 @@ PhilanthroPy is a production-ready Python library that slots directly into `skle
 
 Get up and running in seconds:
 
+!!! info "Current release: 0.6.0"
+    `pip install philanthropy` gives you **0.6.0**. These docs are built from
+    `main`, which also carries the merged-but-unreleased 0.7.0 and 1.0.0 work —
+    see [Deprecations](reference/index.md#deprecations) for the handful of
+    differences that affect you today.
+
 === "pip"
     ```bash
     pip install philanthropy

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -83,17 +83,44 @@ Every domain method returns a number on its own scale. None of them are calibrat
 
 ## Deprecations
 
-Nothing is currently deprecated. The 0.6.0 shims — `predict_ask_array`,
-`predict_capacity_ratio`, `predict_action_priority`,
-`predict_bequest_intent_score` — and the three dead constructor parameters
-`LapsePredictor(lapse_window_years=...)`, `PropensityScorer(estimator=...)` and
-`FiscalYearGroupedSplitter(fiscal_year_start=...)` were all removed in 0.7.0
-after one full published minor of `DeprecationWarning` overlap.
+!!! info "This page is built from `main`, which is ahead of the release"
+    `pip install philanthropy` currently gives you **0.6.0**. The tier tables
+    above describe the API as it stands on `main`; the deprecations below are
+    live in the version you actually have installed.
 
-0.7.0 also made `donor_acquisition_cost`, `cost_per_dollar_raised` and
-`fundraising_roi` keyword-only, and moved four accidental second import paths
-behind underscores: `metrics.scoring` → `metrics._scoring`,
+### Live in 0.6.0 — removed in 0.7.0
+
+These still work and emit `DeprecationWarning`. Migrate before upgrading.
+
+| Deprecated | Use instead |
+|---|---|
+| `AskAmountRecommender.predict_ask_array` | `ask_ladder` |
+| `ShareOfWalletRegressor.predict_capacity_ratio` | `capacity_ratio` |
+| `MovesManagementClassifier.predict_action_priority` | `action_priority` |
+| `PlannedGivingIntentScorer.predict_bequest_intent_score` | `predict_intent_score` |
+
+The `predict_` prefix is reserved for methods that take `X` alone and return one
+value per row. The first three returned a `(n, 3)` dollar matrix, required a
+second argument, and returned a dict respectively.
+
+Three constructor parameters have no effect and warn when set to a non-default
+value — `LapsePredictor(lapse_window_years=...)`,
+`PropensityScorer(estimator=...)`,
+`FiscalYearGroupedSplitter(fiscal_year_start=...)`. All three are removed in
+0.7.0.
+
+### Already merged for 0.7.0
+
+Beyond removing everything above, 0.7.0 makes `donor_acquisition_cost`,
+`cost_per_dollar_raised` and `fundraising_roi` **keyword-only** — they do not
+share an argument order, so a positional call was silently accepted and returned
+a plausible wrong number. Write them with keywords today and the upgrade is a
+no-op.
+
+It also moves four accidental second import paths behind underscores, so 1.0
+does not freeze them: `metrics.scoring` → `metrics._scoring`,
 `preprocessing.transformers` → `preprocessing._transformers`,
 `models.propensity` → `models._propensity_baseline`, `utils.testing` →
-`utils._testing`. The public symbols they export are unchanged; import them
-from the subpackage, as the documented examples always have.
+`utils._testing`. Every public symbol they export is unchanged — import from the
+subpackage (`from philanthropy.metrics import ...`), as the documented examples
+always have, and nothing breaks.


### PR DESCRIPTION
`main` is at 1.0.0, PyPI serves 0.6.0, and the docs site builds from `main`. That combination was telling readers two things that are not true:

| Surface | Claimed | Actually true for `pip install philanthropy` |
|---|---|---|
| README maturity | "v1.0.0, Tier 1 semver-protected" | 0.6.0 — freezes nothing |
| Reference index | "Nothing is currently deprecated" | 0.6.0 ships 4 deprecated aliases + 3 dead params, all warning |

### Changes

- **README** leads with "`pip install philanthropy` gives you 0.6.0" and explains *why* 0.7.0/1.0.0 are held back — the migration window is deliberate, not an oversight. Tier semantics kept, correctly scoped to "from 1.0.0".
- **Reference index** splits Deprecations into **Live in 0.6.0** (what to migrate off, with the replacement for each) and **Already merged for 0.7.0**, behind an admonition noting the page builds from `main`.
- **Docs landing page** carries the same banner where a first-time reader arrives.

Also adds the practical note that writing `donor_acquisition_cost` / `cost_per_dollar_raised` / `fundraising_roi` with keyword arguments **today** makes the 0.7.0 keyword-only change a no-op.

`mkdocs build --strict` clean; all 15 executable doc pages still pass.