### PR TITLE
docs: make the release checklist runnable again

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,7 @@ tiers live in [docs/reference/index.md](docs/reference/index.md).
 
 Run in order. Steps 1–6 are the gate `publish.yml` enforces; 7–9 are manual.
 
-1. `make ci` is green, and so is `pytest tests/test_public_api_contract.py
-   tests/test_deprecations.py -q`.
+1. `make ci` is green, and so is `pytest tests/test_public_api_contract.py -q`.
 2. Bump `version` in `pyproject.toml`. Nothing else carries the version —
    `philanthropy.__version__` reads it from installed metadata.
 3. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`. The date is
@@ -97,7 +96,7 @@ Run in order. Steps 1–6 are the gate `publish.yml` enforces; 7–9 are manual.
    needs a **Breaking** heading; a release that adds a shim needs a
    **Deprecated** heading naming every alias and dead parameter with the version
    that removes it.
-4. Update the "Deprecations in flight" table in `docs/reference/index.md`.
+4. Update the "Deprecations" section of `docs/reference/index.md`.
 5. `python -m build && python -m twine check --strict dist/*`.
 6. Tag `vX.Y.Z` and push it. Publishing is gated on clicking **Publish release**
    in the GitHub UI; `publish.yml` then re-checks that the tag, `pyproject.toml`
@@ -114,3 +113,30 @@ Run in order. Steps 1–6 are the gate `publish.yml` enforces; 7–9 are manual.
 
 A shim added in `X.Y.0` may only be removed in `X.(Y+1).0` **after `X.Y.0` is
 published on PyPI** — one full published minor of overlap, not one commit.
+
+### Cutting a release `main` has already moved past
+
+`main` can carry more than one unreleased version — 0.7.0 and 1.0.0 are both
+merged and both still `- TBD`. The gate compares the tag against the
+`pyproject.toml` **of the commit the tag points at**, so once a later version
+has bumped that file at the tip, the older release can no longer be cut from the
+tip: `v0.7.0` against a `main` reading `version = "1.0.0"` fails with
+`tag != pyproject 1.0.0`, dated changelog or not. Step 2 above assumes one
+version in flight; with several staged, tag the last commit that still reads the
+older version — `e1713c4` for 0.7.0:
+
+```bash
+git switch -c release/0.7.0 e1713c4
+# step 3: date the '## [0.7.0]' heading in CHANGELOG.md
+git commit -am "chore: date the 0.7.0 release"
+git push origin release/0.7.0 && git tag v0.7.0 && git push origin v0.7.0
+```
+
+The branch is not a fork of the release pipeline. A `release` event only fires
+for a workflow file that "exists on the default branch", so `publish.yml` is
+always the one on `main`; `actions/checkout` with no `ref` "defaults to the
+reference or SHA for that event", which is the tagged commit. The old tree gets
+the current gate and the current action pins.
+
+Then date the same heading on `main`, so its changelog stops claiming `- TBD`
+for something that shipped.


### PR DESCRIPTION
The parked plan for 0.7.0 — "date the `## [0.7.0]` heading, tag `v0.7.0`, push" — does not work. Simulating `publish.yml`'s gate against `main` HEAD:

```
v0.7.0 on main HEAD -> FAIL: tag v0.7.0 != pyproject 1.0.0 | FAIL: heading undated
v1.0.0 on main HEAD -> tag==pyproject OK                   | FAIL: heading undated
```

`9aa956f` bumped `pyproject.toml` to `1.0.0`, and the gate compares the tag against the `pyproject.toml` of the commit the tag points at. Dating the heading never gets a look in — tag-vs-version fails first. The last commit reading `version = "0.7.0"` is `e1713c4`, so that is where `v0.7.0` has to go.

Three fixes to `CONTRIBUTING.md`:

- **Step 1** referenced `tests/test_deprecations.py`, deleted in `e1713c4` with the shims it policed. The first step of a release errored out. Now `pytest tests/test_public_api_contract.py -q` — verified, 81 passed.
- **New section** "Cutting a release `main` has already moved past" with the `release/0.7.0` command sequence, plus why tagging an old commit is safe: a `release` event only fires for a workflow file that "exists on the default branch", so the gate and action pins are always `main`'s, while `actions/checkout` with no `ref` "defaults to the reference or SHA for that event" and builds the tagged tree.
- **Step 4** pointed at a "Deprecations in flight" table; the section in `docs/reference/index.md` is called `Deprecations`.

Docs only, no code touched. `make ci` green on this branch (exit 0 — flake8, mypy, doctests, collection, full suite, coverage `fail_under = 92`). `CONTRIBUTING.md` is not in `test_doc_examples.py`'s `DOC_FILES`, so the new bash block is not executed by the suite.

Not in scope: `publish.yml` still pins `actions/setup-python@v5` while v7 is current. Leaving it — v5 also runs in `ci.yml` (×4) and `docs.yml` on every push, so it is well exercised, whereas bumping it would put an untested change on the one path that cannot be tested before a real release.