### PR TITLE
docs: make the contributor path followable end to end

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,31 @@ Thanks for helping improve PhilanthroPy! This guide covers the local checks
 every change must pass before it reaches CI. By participating you agree to abide
 by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
+New here? Start with a
+[good first issue](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+— each one names the files to touch and the single command that proves it is
+done. A first PR does not need to be big; docs fixes and missing tests are
+genuinely wanted. Comment on the issue to claim it, and ask there if anything in
+this guide does not work — a question is a valid contribution too.
+
 ## Setup
 
+Fork the repository on GitHub first — you will not have push access to
+`PhilanthroPy-Project/PhilanthroPy`.
+
 ```bash
-git clone https://github.com/PhilanthroPy-Project/PhilanthroPy.git
+git clone https://github.com/<your-username>/PhilanthroPy.git
 cd PhilanthroPy
+git remote add upstream https://github.com/PhilanthroPy-Project/PhilanthroPy.git
+git switch -c my-change         # never work on main
 pip install -e ".[dev]"          # editable install so the working tree is what's tested
 sh scripts/install_hooks.sh      # pre-push hook: runs the suite before every push
 ```
 
 Install editable — a non-editable copy in site-packages will shadow your edits
 under pytest and silently run stale code.
+
+Expect the install plus a first green `make ci` to take about eight minutes.
 
 ## Before pushing any commit
 
@@ -24,15 +38,24 @@ Always run the full local gate first:
 make ci
 ```
 
-This runs the same checks as GitHub Actions, in order:
+This runs, in order:
 1. Lint (flake8 — real defects only)
 2. Type check (mypy)
 3. Collection check — catches missing imports immediately
 4. Docstring examples (`--doctest-modules`)
 5. Full test suite
-6. Coverage gate (branch coverage ≥ 92% overall, ≥ 93% on the risk tier)
+6. Coverage gate (branch coverage ≥ 92% overall)
 
-If `make ci` passes, your push will pass CI.
+If `make ci` passes, the lint, type, test, and overall-coverage jobs will pass
+CI. CI checks four more things `make ci` does not:
+
+- a **risk-tier coverage floor** of 93% over `preprocessing/`, `models/`,
+  `metrics/`, and `model_selection/` — reproduce it locally with
+  `python -m coverage report --include='philanthropy/preprocessing/*,philanthropy/models/*,philanthropy/metrics/*,philanthropy/model_selection/*' --fail-under=93`
+- the declared **dependency floors** on Python 3.9 (`uv pip install --resolution lowest-direct`)
+- `python -m build` plus `twine check` on the built distributions
+- a **minimal install** (`pip install .`) that must import without matplotlib
+
 Never use `git push --no-verify`.
 
 When adding a new test file that imports a new class:
@@ -41,7 +64,7 @@ When adding a new test file that imports a new class:
 - Verify: `python -c "from philanthropy.X import Y; print('OK')"`
 - THEN write the test file
 - THEN run `make ci`
-- THEN git add + commit + push
+- THEN git add + commit
 
 A single test file must never assert contradictory shapes or column counts for
 the same transformer. Before committing a test file, run:
@@ -51,6 +74,20 @@ grep -n "shape\|columns\|n_by" tests/<file>.py
 ```
 
 and confirm all shape assertions are consistent with each other.
+
+## Opening the pull request
+
+```bash
+git push origin my-change        # your fork, not upstream
+```
+
+Then open a pull request against `PhilanthroPy-Project/PhilanthroPy` `main`.
+GitHub offers the button on your fork right after the push. Fill in the
+[PR template](.github/PULL_REQUEST_TEMPLATE.md): what changed and why, and add a
+`CHANGELOG.md` entry under `[Unreleased]`.
+
+CI runs on pull requests from forks. If a job fails, push another commit to the
+same branch — the PR updates itself.
 
 ## Additional checks
 
@@ -67,76 +104,11 @@ python -m pytest <new_test_file.py> --collect-only -q
 
 ## Versioning & deprecation
 
-PhilanthroPy follows [Semantic Versioning](https://semver.org). While the
-project is pre-1.0, minor releases (`0.x.0`) may contain breaking changes; these
-are always called out under a **Breaking** heading in
-[CHANGELOG.md](CHANGELOG.md). Where feasible, a deprecated public API is kept for
-at least one minor release and emits a `DeprecationWarning` pointing at its
-replacement before removal. Supported versions are listed in
-[SECURITY.md](SECURITY.md).
+PhilanthroPy follows [Semantic Versioning](https://semver.org). Breaking changes
+are called out under a **Breaking** heading in [CHANGELOG.md](CHANGELOG.md), and
+a deprecated public API emits a `DeprecationWarning` for at least one minor
+release before removal. Per-symbol stability tiers are in
+[docs/reference/index.md](docs/reference/index.md).
 
-Nothing is deprecated at 0.7.0. When you next need to deprecate something,
-reintroduce the one mechanism 0.6.0 used: a `deprecated_alias(new_name,
-removed_in=...)` decorator in `philanthropy/utils/_deprecation.py` for a renamed
-method, and an inline `warnings.warn(..., DeprecationWarning)` in `fit`/`split`
-for a parameter that no longer does anything — plus a `tests/test_deprecations.py`
-whose registry meta-test fails when a shim ships untested. Per-symbol stability
-tiers live in [docs/reference/index.md](docs/reference/index.md).
-
-## RELEASE CHECKLIST
-
-Run in order. Steps 1–6 are the gate `publish.yml` enforces; 7–9 are manual.
-
-1. `make ci` is green, and so is `pytest tests/test_public_api_contract.py -q`.
-2. Bump `version` in `pyproject.toml`. Nothing else carries the version —
-   `philanthropy.__version__` reads it from installed metadata.
-3. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`. The date is
-   required — `publish.yml` rejects a heading still carrying `- TBD`, which is
-   what a release staged ahead of its window looks like. A release that removes anything
-   needs a **Breaking** heading; a release that adds a shim needs a
-   **Deprecated** heading naming every alias and dead parameter with the version
-   that removes it.
-4. Update the "Deprecations" section of `docs/reference/index.md`.
-5. `python -m build && python -m twine check --strict dist/*`.
-6. Tag `vX.Y.Z` and push it. Publishing is gated on clicking **Publish release**
-   in the GitHub UI; `publish.yml` then re-checks that the tag, `pyproject.toml`
-   and `CHANGELOG.md` agree before it builds.
-7. Confirm the release landed on PyPI and that `pip install philanthropy==X.Y.Z`
-   works in a clean venv.
-8. **Deposit to Zenodo.** The GitHub–Zenodo integration picks up the published
-   release and reads `.zenodo.json`. JOSS requires a deposited archive with a DOI
-   at acceptance.
-9. On the first deposit only: copy the Zenodo **concept** DOI (the one that
-   resolves to the latest version, not the per-version DOI) into the
-   `identifiers:` stanza of `CITATION.cff`, replacing
-   `10.5281/zenodo.PENDING`, and commit.
-
-A shim added in `X.Y.0` may only be removed in `X.(Y+1).0` **after `X.Y.0` is
-published on PyPI** — one full published minor of overlap, not one commit.
-
-### Cutting a release `main` has already moved past
-
-`main` can carry more than one unreleased version — 0.7.0 and 1.0.0 are both
-merged and both still `- TBD`. The gate compares the tag against the
-`pyproject.toml` **of the commit the tag points at**, so once a later version
-has bumped that file at the tip, the older release can no longer be cut from the
-tip: `v0.7.0` against a `main` reading `version = "1.0.0"` fails with
-`tag != pyproject 1.0.0`, dated changelog or not. Step 2 above assumes one
-version in flight; with several staged, tag the last commit that still reads the
-older version — `e1713c4` for 0.7.0:
-
-```bash
-git switch -c release/0.7.0 e1713c4
-# step 3: date the '## [0.7.0]' heading in CHANGELOG.md
-git commit -am "chore: date the 0.7.0 release"
-git push origin release/0.7.0 && git tag v0.7.0 && git push origin v0.7.0
-```
-
-The branch is not a fork of the release pipeline. A `release` event only fires
-for a workflow file that "exists on the default branch", so `publish.yml` is
-always the one on `main`; `actions/checkout` with no `ref` "defaults to the
-reference or SHA for that event", which is the tagged commit. The old tree gets
-the current gate and the current action pins.
-
-Then date the same heading on `main`, so its changelog stops claiming `- TBD`
-for something that shipped.
+Cutting a release is a maintainer task and needs PyPI, Zenodo, and GitHub
+release permissions — the runbook lives in [RELEASING.md](RELEASING.md).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Single-maintainer MIT project. **`pip install philanthropy` gives you `0.6.0`**,
 
 Preprocessing and the core classifiers are Tier 1; grateful-patient featurization and `philanthropy.ingest` are Tier 2 (Beta); `FinancialForecastModel` and `philanthropy.experimental.*` are Tier 3 (Experimental) and carry no API guarantees. From `1.0.0`, Tier 1 becomes semver-protected — breaking one requires a major release preceded by a full published minor of `DeprecationWarning`. Per-symbol tiers are in the [API reference](docs/reference/index.md).
 
-> **Maintenance:** maintained by one person on a best-effort basis. For vendor / OSS risk reviews: the bus factor is 1. Issues and PRs are welcome.
+> **Maintenance:** maintained by one person on a best-effort basis. For vendor / OSS risk reviews: the bus factor is 1.
 
 ---
 
@@ -190,9 +190,20 @@ benchmark of PhilanthroPy.** To cite the software itself, see [`CITATION.cff`](C
 
 ## Contributing
 
-See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full local test gate, the
-new-test-file workflow, and pre-push hook setup. In short: run `make ci` before
-every push, and never use `git push --no-verify`.
+Contributions are welcome, and a first PR does not need to be big — docs fixes,
+missing tests, and clearer error messages all count.
+
+**Start with a [good first issue](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).**
+Each one names the files to touch, the steps, and the single command that proves
+it is done. Comment on the issue to claim it; ask there if anything is unclear.
+
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the fork-and-PR workflow, the full
+local test gate, and pre-push hook setup. In short: fork, branch, run `make ci`
+before every push, and never use `git push --no-verify`. Setup plus a first green
+`make ci` takes about eight minutes.
+
+Questions are welcome in
+[Discussions](https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions).
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing PhilanthroPy
+
+Maintainer runbook. Cutting a release needs PyPI, Zenodo, and GitHub release
+permissions — contributors do not need anything on this page. For contributing,
+see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Versioning & deprecation
+
+PhilanthroPy follows [Semantic Versioning](https://semver.org). While the
+project is pre-1.0, minor releases (`0.x.0`) may contain breaking changes; these
+are always called out under a **Breaking** heading in
+[CHANGELOG.md](CHANGELOG.md). Where feasible, a deprecated public API is kept for
+at least one minor release and emits a `DeprecationWarning` pointing at its
+replacement before removal. Supported versions are listed in
+[SECURITY.md](SECURITY.md).
+
+Nothing is deprecated at 0.7.0. When you next need to deprecate something,
+reintroduce the one mechanism 0.6.0 used: a `deprecated_alias(new_name,
+removed_in=...)` decorator in `philanthropy/utils/_deprecation.py` for a renamed
+method, and an inline `warnings.warn(..., DeprecationWarning)` in `fit`/`split`
+for a parameter that no longer does anything — plus a `tests/test_deprecations.py`
+whose registry meta-test fails when a shim ships untested. Per-symbol stability
+tiers live in [docs/reference/index.md](docs/reference/index.md).
+
+## RELEASE CHECKLIST
+
+Run in order. Steps 1–6 are the gate `publish.yml` enforces; 7–9 are manual.
+
+1. `make ci` is green, and so is `pytest tests/test_public_api_contract.py -q`.
+2. Bump `version` in `pyproject.toml`. Nothing else carries the version —
+   `philanthropy.__version__` reads it from installed metadata.
+3. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`. The date is
+   required — `publish.yml` rejects a heading still carrying `- TBD`, which is
+   what a release staged ahead of its window looks like. A release that removes anything
+   needs a **Breaking** heading; a release that adds a shim needs a
+   **Deprecated** heading naming every alias and dead parameter with the version
+   that removes it.
+4. Update the "Deprecations" section of `docs/reference/index.md`.
+5. `python -m build && python -m twine check --strict dist/*`.
+6. Tag `vX.Y.Z` and push it. Publishing is gated on clicking **Publish release**
+   in the GitHub UI; `publish.yml` then re-checks that the tag, `pyproject.toml`
+   and `CHANGELOG.md` agree before it builds.
+7. Confirm the release landed on PyPI and that `pip install philanthropy==X.Y.Z`
+   works in a clean venv.
+8. **Deposit to Zenodo.** The GitHub–Zenodo integration picks up the published
+   release and reads `.zenodo.json`. JOSS requires a deposited archive with a DOI
+   at acceptance.
+9. On the first deposit only: copy the Zenodo **concept** DOI (the one that
+   resolves to the latest version, not the per-version DOI) into the
+   `identifiers:` stanza of `CITATION.cff`, replacing
+   `10.5281/zenodo.PENDING`, and commit.
+
+A shim added in `X.Y.0` may only be removed in `X.(Y+1).0` **after `X.Y.0` is
+published on PyPI** — one full published minor of overlap, not one commit.
+
+### Cutting a release `main` has already moved past
+
+`main` can carry more than one unreleased version — 0.7.0 and 1.0.0 are both
+merged and both still `- TBD`. The gate compares the tag against the
+`pyproject.toml` **of the commit the tag points at**, so once a later version
+has bumped that file at the tip, the older release can no longer be cut from the
+tip: `v0.7.0` against a `main` reading `version = "1.0.0"` fails with
+`tag != pyproject 1.0.0`, dated changelog or not. Step 2 above assumes one
+version in flight; with several staged, tag the last commit that still reads the
+older version — `e1713c4` for 0.7.0:
+
+```bash
+git switch -c release/0.7.0 e1713c4
+# step 3: date the '## [0.7.0]' heading in CHANGELOG.md
+git commit -am "chore: date the 0.7.0 release"
+git push origin release/0.7.0 && git tag v0.7.0 && git push origin v0.7.0
+```
+
+The branch is not a fork of the release pipeline. A `release` event only fires
+for a workflow file that "exists on the default branch", so `publish.yml` is
+always the one on `main`; `actions/checkout` with no `ref` "defaults to the
+reference or SHA for that event", which is the tagged commit. The old tree gets
+the current gate and the current action pins.
+
+Then date the same heading on `main`, so its changelog stops claiming `- TBD`
+for something that shipped.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,35 @@
+# Contributing
+
+PhilanthroPy takes outside contributions. Docs fixes, missing tests, and clearer
+error messages are as welcome as new estimators — a first PR does not need to be
+big.
+
+## Start here
+
+Pick a
+[good first issue](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+Each one names the exact files to touch, the steps to follow, and the single
+command that proves the work is done. Comment on the issue to claim it.
+
+Nothing there that suits you? Open an issue describing what you want to change
+before writing the code, so nobody spends an evening on something that would be
+turned down.
+
+## The workflow
+
+Fork, branch, run `make ci`, push to your fork, open a pull request against
+`main`. The full setup — including the local gate and the four extra checks CI
+runs on top of it — is in
+[CONTRIBUTING.md](https://github.com/PhilanthroPy-Project/PhilanthroPy/blob/main/CONTRIBUTING.md).
+
+Setup plus a first green `make ci` takes about eight minutes.
+
+## Questions
+
+Ask in
+[Discussions](https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions),
+or on the issue you are working on. Asking is a valid contribution — if
+something in the guide does not work, that is a bug in the guide.
+
+By participating you agree to abide by the
+[Code of Conduct](https://github.com/PhilanthroPy-Project/PhilanthroPy/blob/main/CODE_OF_CONDUCT.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - explanation/compliance_considerations.md
     - explanation/comparison_to_vendors.md
     - explanation/benchmarks.md
+  - Contributing: contributing.md
   - API Reference:
     - reference/index.md
     - reference/preprocessing.md


### PR DESCRIPTION
## What & why

A stranger who wants to contribute currently cannot follow the instructions to completion. `grep -n "fork|pull request"` across `CONTRIBUTING.md`, `README.md`, and `docs/how-to/develop_and_test.md` returns exactly one hit, and it is an unrelated sentence about release tagging.

The setup block hands out the upstream clone URL and ends with "THEN git add + commit + push". For anyone without write access that push is a 403 — and it comes *after* the pre-push hook has already run the full suite.

## Changes

- **`CONTRIBUTING.md`** — adds the fork → branch → PR workflow, and an opening that points at the labelled good-first-issues.
- **`CONTRIBUTING.md`** — corrects "If `make ci` passes, your push will pass CI." It does not. CI additionally enforces a 93% risk-tier coverage floor (`ci.yml:74-78`), dependency floors on Python 3.9, a distribution build check, and a matplotlib-free install. The risk-tier command is now spelled out so it can be reproduced locally.
- **`RELEASING.md`** (new) — the release runbook moves out of `CONTRIBUTING.md`, where it was 76 of 142 lines and needed PyPI, Zenodo, and GitHub release credentials no contributor has. `CONTRIBUTING.md` drops from 179 to 114 lines.
- **`docs/contributing.md`** (new) + `mkdocs.yml` nav — `grep -n contribut mkdocs.yml` returned 0 matches, so the published docs site had no contributing page at all.
- **`README.md`** — a real Contributing section, instead of "Issues and PRs are welcome" as the last clause of a blockquote addressed to vendor OSS risk reviewers.

## Verification

```
$ python -m flake8 philanthropy tests examples   # exit 0
$ python -m mypy philanthropy
mypy: No issues found
$ python -m pytest philanthropy --doctest-modules -q --no-cov
26 passed
$ python -m pytest tests/ -q --cov=philanthropy
Required test coverage of 92.0% reached. Total coverage: 94.64%
1628 passed, 2 skipped in 100.10s
$ python -m mkdocs build --strict                # clean
```

## Checklist
- [x] `make ci` passes locally (lint → collection → tests → coverage ≥ 92%)
- [x] New/changed public API has docstrings and is exported in the subpackage `__init__.py` — n/a, docs only
- [x] Tests added or updated — n/a, docs only
- [ ] `CHANGELOG.md` updated under `[Unreleased]` — docs-only, no user-facing API change