### PR TITLE
docs: disclose generative AI use in README and the package docstring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ site/
 
 # Saved model artifacts
 *.joblib
+
+# Local working notes (not published)
+plan.md

--- a/README.md
+++ b/README.md
@@ -188,6 +188,35 @@ benchmark of PhilanthroPy.** To cite the software itself, see [`CITATION.cff`](C
 
 ---
 
+## Generative AI disclosure
+
+AI assistance (Claude Code) was used during development of this package, across
+implementation, tests, and documentation, in an agentic workflow rather than
+line completion alone.
+
+**What was not generated.** The design constraints are the author's and predate
+any generated code: the leakage-safety contract (every fitted statistic is
+computed on training data inside `fit` and frozen before `transform`/`predict`),
+the dependency rule (scikit-learn, pandas, numpy, matplotlib, seaborn — no deep
+learning frameworks), the estimator conventions, and the stability tiers.
+Generated code that violated them was rejected rather than merged.
+
+**Human review.** Nothing lands without the full gate green. Locally, `make ci`
+runs flake8, mypy, the docstring examples, and the test suite against a 92%
+coverage floor (`pyproject.toml`). CI additionally enforces a 93% coverage floor
+on the risk-tier subtree, runs the suite across an OS and Python-version matrix,
+installs at the declared dependency floors on Python 3.9, builds the
+distributions and checks their metadata with `twine`, and verifies the package
+imports without a plotting stack installed. Every public estimator passes
+`sklearn.utils.estimator_checks.check_estimator`.
+
+No approximate scale is attached to the AI use here. The author has not measured
+the split and will not estimate one; the mechanism and the review gate above are
+stated instead. This follows the
+[pyOpenSci generative AI policy](https://www.pyopensci.org/blog/generative-ai-peer-review-policy.html).
+
+---
+
 ## Contributing
 
 Contributions are welcome, and a first PR does not need to be big — docs fixes,

--- a/philanthropy/__init__.py
+++ b/philanthropy/__init__.py
@@ -3,6 +3,14 @@ PhilanthroPy
 ============
 A scikit-learn compatible toolkit for predictive donor analytics
 in the nonprofit sector.
+
+Generative AI disclosure
+------------------------
+AI assistance (Claude Code) was used during development of this package.
+The scope is package-wide rather than specific to any one module, so the
+disclosure lives here rather than being stamped on every module. See the
+"Generative AI disclosure" section of README.md for how the tools were
+used and what human review was performed.
 """
 
 from importlib.metadata import PackageNotFoundError, version as _version


### PR DESCRIPTION
pyOpenSci's [generative AI policy](https://www.pyopensci.org/blog/generative-ai-peer-review-policy.html) asks for three things, and the repo stated none of them: disclosure in `README.md` **and at the top of relevant modules**, a description of **how** the tools were used, and what **human review** was performed. The presubmission inquiry (pyOpenSci/software-submission#337) is open and an editor can ask directly.

## What this adds

- **`README.md` — a `## Generative AI disclosure` section.** The mechanism (agentic workflow, not line completion), what was *not* generated — the leakage-safety contract, the dependency rule, the estimator conventions, the stability tiers — and the review gate every change clears before it lands.
- **The root package docstring** carries the same disclosure. Scope is package-wide, so stamping ~40 modules would repeat one paragraph 40 times; #337 asks the editors whether they want it per-module anyway.

## What it deliberately does not say

No approximate scale. The split has not been measured, and an invented magnitude word in either direction would be worse than saying so plainly. Disclosure carries no penalty under the policy and there is no upside to minimising: the repo is public and reviewers clone repos.

Also in this PR: a one-line `.gitignore` entry for `plan.md`, the maintainer's local outreach/deadline scratchpad, which is not documentation and should never reach someone who cloned the repo to use the library.

## Verification

`make ci` green locally — flake8 clean, `mypy: Success: no issues found in 46 source files`, 26 doctests, 1628 passed / 2 skipped, coverage 94.64% against the 92% gate.