### PR TITLE
feat: bridge CiviCRM contribution exports into the feature table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- **CiviCRM contribution bridge** — `philanthropy.ingest.read_civicrm_contributions`
+  and `civicrm_contributions_to_features` (Tier 2). Turns a CiviCRM contribution
+  export, or an APIv4 `Contribution.get` result, into the one-row-per-donor
+  feature table the estimators consume. Headers normalise to the APIv4 spelling,
+  so the human export labels (`Contact ID`, `Total Amount`, `Contribution Date`)
+  and the DB columns (`contact_id`, `total_amount`, `receive_date`) both work.
+
+  It exists because two things a bare `pd.read_csv` gets wrong are expensive:
+  CiviCRM writes payment-processor **test transactions** into the same table, and
+  `contribution_status` separates `Completed` from `Pending`, `Failed`,
+  `Refunded` and `Chargeback`. Test rows are always dropped; only `Completed` is
+  counted unless `statuses` says otherwise, and asking for a status filter that
+  cannot be applied warns instead of silently summing refunds.
+
+  Recency is anchored to `reference_date` or the batch's latest gift, never a
+  moving "now" — the same leakage contract as the UniSchema bridge. See
+  [docs/how-to/ingest_civicrm_contributions.md](docs/how-to/ingest_civicrm_contributions.md).
+
 ## [1.0.0] - TBD
 
 The API freeze. No code changes — 1.0.0 is a promise, not a feature.

--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ assert len(set(scores.round(6))) > 1       # a constant score means a broken pip
 
 ---
 
-## From UniSchema events to scores
+## From your CRM to scores
 
-PhilanthroPy is the modeling half of an ecosystem. [UniSchema](https://github.com/PhilanthroPy-Project/UniSchema) normalizes fragmented advancement webhooks (GiveCampus, Slate, NPSP, Cvent, …) into a single `ConstituentEvent` stream. `philanthropy.ingest` turns that stream into the donor-level feature table the estimators expect — no glue code between the two projects.
+`philanthropy.ingest` is the on-ramp: it turns what your donor system already emits into the donor-level feature table the estimators expect, with no glue code in between.
 
-Webhooks → UniSchema egress → `read_constituent_events()` → `constituent_events_to_features()` → `predict_affinity_score()`. Worked, runnable version with the full diagram: **[Ingest UniSchema events](docs/how-to/ingest_unischema_events.md)**.
+**CiviCRM.** A contribution export (or an APIv4 `Contribution.get` result) → `read_civicrm_contributions()` → `civicrm_contributions_to_features()` → `predict_affinity_score()`. The bridge drops payment-processor test transactions and counts only `Completed` contributions, which is the difference between a lifetime-giving number you can brief a gift officer on and one inflated by refunds. Worked version: **[Ingest CiviCRM contributions](docs/how-to/ingest_civicrm_contributions.md)**.
+
+**UniSchema.** PhilanthroPy is also the modeling half of an ecosystem. [UniSchema](https://github.com/PhilanthroPy-Project/UniSchema) normalizes fragmented advancement webhooks (GiveCampus, Slate, NPSP, Cvent, …) into a single `ConstituentEvent` stream. Webhooks → UniSchema egress → `read_constituent_events()` → `constituent_events_to_features()` → `predict_affinity_score()`. Worked, runnable version with the full diagram: **[Ingest UniSchema events](docs/how-to/ingest_unischema_events.md)**.
 
 ---
 
@@ -150,6 +152,7 @@ Full parameter documentation for every symbol below is rendered in the [API refe
 | `FiscalYearGroupedSplitter` | `model_selection` | Walk-forward fiscal-year CV |
 | `donor_feature_importance` | `inspection` | Permutation importance for any fitted estimator |
 | `constituent_events_to_features`, `read_constituent_events` | `ingest` | UniSchema bridge |
+| `civicrm_contributions_to_features`, `read_civicrm_contributions` | `ingest` | CiviCRM contribution-export bridge |
 | `generate_synthetic_donor_data`, `load_ciob_fundraising` | `datasets` | Synthetic pool and a real CIOB series |
 | `make_donor_dataset`, `save_model`, `load_model` | `utils` | Labelled fixtures and pipeline persistence |
 | `plot_affinity_distribution`, `plot_retention_waterfall` | `visualisation` | Matplotlib is imported lazily, per function |
@@ -161,7 +164,7 @@ Full parameter documentation for every symbol below is rendered in the [API refe
 
 **Tutorials** — [Building your first model](docs/tutorials/building_your_first_model.md) · [Avoiding temporal data leakage](docs/tutorials/avoiding_temporal_data_leakage.md) · [Building a grateful-patient pipeline](docs/tutorials/building_a_grateful_patient_pipeline.md)
 
-**How-to** — [Use the CLI](docs/how-to/use_the_cli.md) · [Ingest UniSchema events](docs/how-to/ingest_unischema_events.md) · [Handle missing wealth data](docs/how-to/handle_missing_wealth_data.md) · [Build grateful-patient features](docs/how-to/build_grateful_patient_features.md) · [Recommend ask amounts](docs/how-to/recommend_ask_amounts.md) · [Score matching-gift eligibility](docs/how-to/score_matching_gift_eligibility.md) · [Measure campaign efficiency](docs/how-to/measure_campaign_efficiency.md) · [Audit score fairness](docs/how-to/audit_score_fairness.md) · [Estimate appeal uplift](docs/how-to/estimate_appeal_uplift.md) · [Save and load models](docs/how-to/save_and_load_models.md) · [Develop and test](docs/how-to/develop_and_test.md)
+**How-to** — [Use the CLI](docs/how-to/use_the_cli.md) · [Ingest UniSchema events](docs/how-to/ingest_unischema_events.md) · [Ingest CiviCRM contributions](docs/how-to/ingest_civicrm_contributions.md) · [Handle missing wealth data](docs/how-to/handle_missing_wealth_data.md) · [Build grateful-patient features](docs/how-to/build_grateful_patient_features.md) · [Recommend ask amounts](docs/how-to/recommend_ask_amounts.md) · [Score matching-gift eligibility](docs/how-to/score_matching_gift_eligibility.md) · [Measure campaign efficiency](docs/how-to/measure_campaign_efficiency.md) · [Audit score fairness](docs/how-to/audit_score_fairness.md) · [Estimate appeal uplift](docs/how-to/estimate_appeal_uplift.md) · [Save and load models](docs/how-to/save_and_load_models.md) · [Develop and test](docs/how-to/develop_and_test.md)
 
 **Explanation** — [Design principles](docs/explanation/design_principles.md) · [Capacity and loyalty](docs/explanation/capacity_and_loyalty.md) · [Fundraising metrics](docs/explanation/fundraising_metrics.md) · [Compliance considerations](docs/explanation/compliance_considerations.md) · [Benchmarks](docs/explanation/benchmarks.md)
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -4,6 +4,7 @@ How-to guides are task recipes. Each one solves a specific problem and assumes y
 
 * [Use the CLI](use_the_cli.md)
 * [Ingest UniSchema Events](ingest_unischema_events.md)
+* [Ingest CiviCRM Contributions](ingest_civicrm_contributions.md)
 * [Handle Missing Wealth Data](handle_missing_wealth_data.md)
 * [Build Grateful Patient Features](build_grateful_patient_features.md)
 * [Recommend Ask Amounts](recommend_ask_amounts.md)

--- a/docs/how-to/ingest_civicrm_contributions.md
+++ b/docs/how-to/ingest_civicrm_contributions.md
@@ -1,0 +1,134 @@
+# Ingest CiviCRM contributions
+
+[CiviCRM](https://civicrm.org) is the CRM most small and mid-sized nonprofits actually run, and its `civicrm_contribution` table is where their giving history lives. `philanthropy.ingest` turns a contribution export into the donor-level feature table the estimators expect — no glue code, and without the two mistakes a bare `pd.read_csv` makes.
+
+```mermaid
+flowchart LR
+    A["CiviCRM<br/>civicrm_contribution"] --> B["CSV export<br/>or APIv4 Contribution.get"]
+    B --> C["read_civicrm_contributions()"]
+    C --> D["civicrm_contributions_to_features()<br/>one row per donor"]
+    D --> E["LapsePredictor<br/>DonorPropensityModel"]
+```
+
+## Both spellings of the same table
+
+CiviCRM names its fields twice. A CSV export writes human labels — `Contact ID`, `Total Amount`, `Contribution Date`. APIv4 returns the underlying database columns — `contact_id`, `total_amount`, `receive_date`. The bridge normalises headers to the APIv4 name, so a hand-run export and a scripted API pull take the same path and produce the same frame.
+
+```python
+from pathlib import Path
+
+import pandas as pd
+
+from philanthropy.ingest import (
+    civicrm_contributions_to_features,
+    read_civicrm_contributions,
+)
+
+# Stand in for a CiviCRM "Export Contributions" CSV.
+export = Path("civicrm_export.csv")
+export.write_text(
+    "Contribution ID,Contact ID,Contribution Date,Total Amount,Currency,"
+    "Contribution Status,Financial Type,Test Mode,Email\n"
+    "1,101,2025-01-15,250.00,USD,Completed,Donation,0,ada@uni.edu\n"
+    "2,101,2025-06-01,1000.00,USD,Completed,Member Dues,0,ada@uni.edu\n"
+    "3,101,2025-06-05,99.00,USD,Failed,Donation,0,ada@uni.edu\n"
+    "4,202,2025-03-01,5000.00,USD,Completed,Donation,1,grace@uni.edu\n"
+    "5,202,2025-04-10,750.00,USD,Completed,Donation,0,grace@uni.edu\n"
+)
+
+contributions = read_civicrm_contributions(export)
+print(sorted(contributions.columns))
+```
+
+`read_civicrm_contributions` also accepts a **directory**, walked recursively — the shape you get from keeping a folder of monthly exports. Files are concatenated in sorted relative-path order, symlinks are not followed, and an Excel byte-order mark on the first header is stripped.
+
+Reading is deliberately lossless: every row arrives as text, and nothing is filtered. Policy lives in the aggregation step, so the raw export stays inspectable.
+
+## Two things a bare `read_csv` gets wrong
+
+```python
+features = civicrm_contributions_to_features(
+    contributions, reference_date="2025-07-01"
+)
+print(features[["total_gift_amount", "gift_count", "largest_gift_amount"]])
+
+# Row 3 is Failed and row 4 is a payment-processor test transaction.
+assert float(features.loc["101", "total_gift_amount"]) == 1250.0   # not 1349
+assert float(features.loc["202", "total_gift_amount"]) == 750.0    # not 5750
+```
+
+**Test-mode rows are real rows.** CiviCRM writes payment-processor test transactions into the same table, flagged `is_test` / `Test Mode`. They are always dropped — that is money nobody gave.
+
+**A contribution is not a payment.** `contribution_status` separates `Completed` from `Pending`, `Failed`, `Refunded`, `Cancelled` and `Chargeback`. Only `Completed` is counted by default. Widen it when you mean to:
+
+```python
+with_pledges = civicrm_contributions_to_features(
+    contributions, reference_date="2025-07-01", statuses=("Completed", "Pending")
+)
+everything = civicrm_contributions_to_features(
+    contributions, reference_date="2025-07-01", statuses=None
+)
+assert float(everything.loc["101", "total_gift_amount"]) == 1349.0
+```
+
+If you ask for a status filter and the export has no `Contribution Status` column, the bridge raises a `UserWarning` rather than silently counting refunds. Add the field to your export mapping — or pass `statuses=None` to say you meant it.
+
+## The output is already an RFM table
+
+One row per donor, indexed by `contact_id`:
+
+| Column | Built from |
+|---|---|
+| `constituent_email`, `first_name`, `last_name` | identity fields, carried through when present |
+| `total_gift_amount`, `gift_count`, `largest_gift_amount` | counted contributions |
+| `first_gift_date`, `last_gift_date` | earliest / latest counted contribution |
+| `years_active`, `recency_days` | first / last gift vs. the reference date |
+| `distinct_financial_types` | breadth across Donation, Member Dues, Event Fee, … |
+
+`recency_days`, `gift_count` and `total_gift_amount` are the R, F and M of an RFM model, so you do not need `RFMTransformer` on top of this — it is already aggregated.
+
+**Leakage-safe.** Recency is anchored to the `reference_date` you pass, or to the latest gift in the batch — never to a moving "now". Pass it explicitly whenever you are rebuilding a historical training set, or a rerun next month silently produces different features.
+
+**Replay-safe.** Two rows sharing a CiviCRM `Contribution ID` are the same contribution, and overlapping monthly exports are how that happens. They are collapsed, so a re-read does not double-count a gift.
+
+```python
+replayed = pd.concat([contributions, contributions], ignore_index=True)
+doubled = civicrm_contributions_to_features(replayed, reference_date="2025-07-01")
+assert doubled["total_gift_amount"].equals(features["total_gift_amount"])
+print("dedup by Contribution ID holds")
+```
+
+## Score the result
+
+Train on your labelled giving history; here the synthetic generator stands in for it.
+
+```python
+import numpy as np
+
+from philanthropy.datasets import generate_synthetic_donor_data
+from philanthropy.models import DonorPropensityModel
+
+history = generate_synthetic_donor_data(n_samples=400, random_state=0)
+model = DonorPropensityModel(n_estimators=50, random_state=0).fit(
+    history[["total_gift_amount", "years_active", "event_attendance_count"]].to_numpy(),
+    history["is_major_donor"].to_numpy(),
+)
+
+# gift_count stands in for the engagement-count feature; a contribution export
+# carries no event attendance.
+cols = ["total_gift_amount", "years_active", "gift_count"]
+features["affinity_score"] = model.predict_affinity_score(features[cols].to_numpy())
+print(features["affinity_score"].round(1))
+
+assert np.isfinite(features["affinity_score"]).all()
+```
+
+Pair the export with an event or engagement feed if you want a real `event_attendance_count` — [Ingest UniSchema events](ingest_unischema_events.md) covers that side.
+
+## Amounts, dates and currencies
+
+`total_amount` is parsed after stripping currency symbols and grouping separators, so an Excel-formatted `$1,250.00` survives the round trip. That assumes `.` is the decimal point; a site exporting `1.250,00` should normalise upstream.
+
+`receive_date` is parsed as a mixed format, because a CSV export writes dates in the site's configured format rather than CiviCRM's stored `YYYY-MM-DD HH:MM:SS`. Ambiguous values resolve month-first (`03/01/2025` is 1 March), so a site configured `dd/mm/yyyy` should hand in an already-parsed datetime column.
+
+`total_gift_amount` is a plain sum. CiviCRM carries a per-row `currency` but the export has no FX rates, so a mixed-currency batch emits a `UserWarning` rather than adding apples to oranges. Normalise upstream if your feed is multi-currency.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -53,6 +53,7 @@ Everything reachable from `philanthropy.__all__` is listed below. A symbol not l
 | `MatchingGiftFeaturizer` | `preprocessing` | The employer-normalisation rules will grow. |
 | `AskAmountRecommender` | `models` | The ask-ladder multipliers are a heuristic. |
 | `constituent_events_to_features`, `read_constituent_events` | `ingest` | Tracks the UniSchema `ConstituentEvent` schema, which is versioned upstream. |
+| `civicrm_contributions_to_features`, `read_civicrm_contributions` | `ingest` | Tracks CiviCRM's contribution export labels and APIv4 field names, which move with the CRM. |
 | `plot_affinity_distribution`, `plot_retention_waterfall` | `visualisation` | Chart composition is presentation, not contract. |
 
 ### Tier 3 — Experimental

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - how-to/index.md
     - how-to/use_the_cli.md
     - how-to/ingest_unischema_events.md
+    - how-to/ingest_civicrm_contributions.md
     - how-to/handle_missing_wealth_data.md
     - how-to/build_grateful_patient_features.md
     - how-to/recommend_ask_amounts.md

--- a/philanthropy/__init__.py
+++ b/philanthropy/__init__.py
@@ -34,7 +34,12 @@ from . import (
     experimental,
     visualisation,
 )
-from .ingest import constituent_events_to_features, read_constituent_events
+from .ingest import (
+    civicrm_contributions_to_features,
+    constituent_events_to_features,
+    read_civicrm_contributions,
+    read_constituent_events,
+)
 
 __all__ = [
     "preprocessing",
@@ -47,6 +52,8 @@ __all__ = [
     "model_selection",
     "experimental",
     "visualisation",
+    "civicrm_contributions_to_features",
     "constituent_events_to_features",
+    "read_civicrm_contributions",
     "read_constituent_events",
 ]

--- a/philanthropy/ingest/__init__.py
+++ b/philanthropy/ingest/__init__.py
@@ -1,20 +1,30 @@
 """
 philanthropy.ingest
 ===================
-On-ramp from a UniSchema ``ConstituentEvent`` stream to a PhilanthroPy
-donor-level feature table.
+On-ramps from an upstream donor system to a PhilanthroPy donor-level feature
+table.
 
-``read_constituent_events`` loads UniSchema's JSON / NDJSON egress files;
-``constituent_events_to_features`` aggregates them into the one-row-per-donor
-feature frame the estimators consume.
+UniSchema: ``read_constituent_events`` loads UniSchema's JSON / NDJSON egress
+files; ``constituent_events_to_features`` aggregates them into the
+one-row-per-donor feature frame the estimators consume.
+
+CiviCRM: ``read_civicrm_contributions`` loads a contribution export CSV;
+``civicrm_contributions_to_features`` aggregates it the same way, dropping
+test-mode and non-``Completed`` rows first.
 """
 
+from ._civicrm import (
+    civicrm_contributions_to_features,
+    read_civicrm_contributions,
+)
 from ._constituent_events import (
     constituent_events_to_features,
     read_constituent_events,
 )
 
 __all__ = [
+    "civicrm_contributions_to_features",
     "constituent_events_to_features",
+    "read_civicrm_contributions",
     "read_constituent_events",
 ]

--- a/philanthropy/ingest/_civicrm.py
+++ b/philanthropy/ingest/_civicrm.py
@@ -1,0 +1,402 @@
+"""
+philanthropy.ingest._civicrm
+============================
+Bridge from a CiviCRM contribution export to a PhilanthroPy donor-level
+feature table.
+
+`CiviCRM <https://civicrm.org>`_ is the CRM most small and mid-sized nonprofits
+actually run, and ``civicrm_contribution`` is where their giving history lives.
+It surfaces that table two ways and they disagree on spelling: a CSV export
+carries human labels (``Contact ID``, ``Total Amount``, ``Contribution Date``),
+while APIv4 returns the underlying DB columns (``contact_id``, ``total_amount``,
+``receive_date``).  Both are accepted here — headers are normalised to the APIv4
+name — so a hand-run export and a scripted API pull take the same code path.
+
+:func:`read_civicrm_contributions` loads the CSV(s);
+:func:`civicrm_contributions_to_features` aggregates the gift log into the
+one-row-per-donor frame the estimators consume.
+
+Two things a bare ``pd.read_csv`` gets wrong, and this bridge does not:
+
+* **Test-mode rows are real rows in the export.** CiviCRM writes payment-processor
+  test transactions to the same table (``is_test`` / ``Test Mode``).  Summing
+  them inflates lifetime giving with money nobody gave, so they are always
+  dropped.
+* **A contribution is not a payment.** ``contribution_status`` separates
+  ``Completed`` from ``Pending``, ``Failed``, ``Refunded``, ``Cancelled`` and
+  ``Chargeback``.  Only ``Completed`` is counted by default.
+
+The aggregation is leakage-safe in the same spirit as the transformers: the
+recency reference point is either supplied explicitly or fixed to the latest
+gift in the batch, never a moving "now".
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from pathlib import Path
+from typing import Iterable, Mapping, Optional, Sequence, Union
+
+import pandas as pd
+
+__all__ = ["civicrm_contributions_to_features", "read_civicrm_contributions"]
+
+DAYS_PER_YEAR = 365.25
+
+# Columns without which there is no gift log to aggregate.
+_REQUIRED = ("contact_id", "receive_date", "total_amount")
+
+_NON_ALNUM = re.compile(r"[^0-9a-z]+")
+
+# Header normalisation (lower-case, non-alphanumerics to "_") already collapses
+# most of the export-label vs. APIv4-name gap: "Total Amount" -> total_amount,
+# "Contact ID" -> contact_id.  This maps the handful that still disagree onto
+# the APIv4 name, which is the canonical spelling in this module.
+_HEADER_ALIASES = {
+    "contribution_id": "id",
+    "contribution_date": "receive_date",  # the schema title for receive_date
+    "date_received": "receive_date",
+    "received_date": "receive_date",
+    "amount": "total_amount",
+    "contribution_amount": "total_amount",
+    "contribution_source": "source",
+    "test_mode": "is_test",
+    "primary_email": "email",
+    "email_address": "email",
+    # APIv4 pseudo-fields: `Contribution.get` returns the numeric id under
+    # `contribution_status_id` and the readable value under
+    # `contribution_status_id:name` / `financial_type_id:label`.  Without these
+    # two an API pull would silently arrive with no status column at all.
+    "contribution_status_id_name": "contribution_status",
+    "financial_type_id_label": "financial_type",
+}
+
+# Ordered (column, dtype) contract for the donor feature table.  Kept explicit
+# so an empty export still yields a correctly-typed, downstream-safe frame.
+_FEATURE_DTYPES: "dict[str, str]" = {
+    "constituent_email": "object",
+    "first_name": "object",
+    "last_name": "object",
+    "total_gift_amount": "float64",
+    "gift_count": "int64",
+    "largest_gift_amount": "float64",
+    "first_gift_date": "datetime64[ns]",
+    "last_gift_date": "datetime64[ns]",
+    "years_active": "float64",
+    "recency_days": "int64",
+    "distinct_financial_types": "int64",
+}
+
+_TRUTHY = {"1", "true", "yes", "y", "t"}
+
+
+def civicrm_contributions_to_features(
+    contributions: Union[Iterable[Mapping], pd.DataFrame],
+    *,
+    reference_date: Optional[Union[str, pd.Timestamp]] = None,
+    statuses: Optional[Sequence[str]] = ("Completed",),
+) -> pd.DataFrame:
+    """Aggregate a CiviCRM contribution log into donor-level features.
+
+    Parameters
+    ----------
+    contributions : iterable of mapping, or DataFrame
+        CiviCRM contribution rows. Accepts the output of
+        :func:`read_civicrm_contributions`, an APIv4 ``Contribution.get``
+        result, or a DataFrame of the same fields, under either the export
+        labels or the APIv4 column names. ``contact_id``, ``receive_date`` and
+        ``total_amount`` are required; ``id``, ``currency``,
+        ``contribution_status``, ``financial_type``, ``is_test``, ``email``,
+        ``first_name`` and ``last_name`` are used when present.
+    reference_date : str or datetime-like, optional
+        Anchor for the recency features (``years_active``, ``recency_days``).
+        If ``None``, the latest ``receive_date`` in the batch is used — this
+        keeps the aggregation reproducible and free of "now" leakage. Naive
+        timestamps are interpreted as UTC.
+    statuses : sequence of str or None, default=``("Completed",)``
+        Contribution statuses to count, matched case-insensitively against
+        ``contribution_status``. ``None`` disables the filter and counts every
+        row, including ``Failed`` and ``Refunded`` ones. Test-mode rows are
+        dropped either way.
+
+    Returns
+    -------
+    features : pandas.DataFrame
+        One row per donor, indexed by ``contact_id``, with the columns declared
+        in ``_FEATURE_DTYPES``. ``recency_days``, ``gift_count`` and
+        ``total_gift_amount`` are the R, F and M of an RFM model. Rows are
+        sorted by ``contact_id`` for determinism.
+
+    Raises
+    ------
+    KeyError
+        If ``contact_id``, ``receive_date`` or ``total_amount`` is absent. An
+        export missing one of them cannot be aggregated at all, and failing
+        here names the field instead of surfacing a bare column lookup later.
+
+    Warns
+    -----
+    UserWarning
+        If ``statuses`` was requested but the batch carries no
+        ``contribution_status`` column — the filter silently counting refunded
+        and failed gifts is exactly the error this bridge exists to prevent.
+    UserWarning
+        If the batch mixes currencies. ``total_gift_amount`` is a plain sum with
+        no FX conversion, so a single-currency export is assumed.
+
+    Examples
+    --------
+    >>> rows = [
+    ...     {"Contact ID": "101", "Contribution Date": "2025-01-15",
+    ...      "Total Amount": "250.00", "Contribution Status": "Completed"},
+    ...     {"Contact ID": "101", "Contribution Date": "2025-06-01",
+    ...      "Total Amount": "1,000.00", "Contribution Status": "Completed"},
+    ...     {"Contact ID": "101", "Contribution Date": "2025-06-02",
+    ...      "Total Amount": "99.00", "Contribution Status": "Failed"},
+    ... ]
+    >>> feats = civicrm_contributions_to_features(rows)
+    >>> float(feats.loc["101", "total_gift_amount"])
+    1250.0
+    >>> int(feats.loc["101", "gift_count"])
+    2
+    """
+    df = _normalise_headers(_to_frame(contributions))
+    if df.empty:
+        return _empty_feature_frame()
+
+    missing = [col for col in _REQUIRED if col not in df.columns]
+    if missing:
+        raise KeyError(
+            f"CiviCRM contribution log is missing {missing}. Export the "
+            f"'Contact ID', 'Contribution Date' and 'Total Amount' fields "
+            f"(APIv4: contact_id, receive_date, total_amount); got "
+            f"{sorted(df.columns)}."
+        )
+
+    df = df.copy()
+
+    # Two rows sharing a CiviCRM contribution id are the same contribution —
+    # concatenating overlapping monthly exports is how that happens. Collapse
+    # only rows with a real id: pandas' duplicated() treats NaN == NaN, which
+    # would drop every id-less gift once any row carries one.
+    if "id" in df.columns:
+        df = df[~(df["id"].notna() & df.duplicated(subset="id"))]
+
+    if "is_test" in df.columns:
+        df = df[~_to_bool(df["is_test"])]
+
+    if statuses is not None:
+        if "contribution_status" in df.columns:
+            wanted = {str(s).strip().casefold() for s in statuses}
+            status = df["contribution_status"].astype("string").str.strip().str.casefold()
+            df = df[status.isin(wanted)]
+        else:
+            warnings.warn(
+                f"CiviCRM contribution log has no contribution_status column, so "
+                f"statuses={tuple(statuses)!r} could not be applied: Pending, "
+                f"Failed, Refunded and Cancelled gifts (if any) are counted in "
+                f"total_gift_amount. Add the 'Contribution Status' field to the "
+                f"export, or pass statuses=None to accept every row.",
+                stacklevel=2,
+            )
+
+    # total_gift_amount is a plain sum; CiviCRM carries a per-row `currency` but
+    # the export has no FX rates, so a mixed-currency batch would add apples to
+    # oranges. Warn rather than convert (rates aren't there) or crash.
+    if "currency" in df.columns and df["currency"].dropna().nunique() > 1:
+        warnings.warn(
+            "CiviCRM contribution log mixes currencies "
+            f"({sorted(df['currency'].dropna().unique())}); total_gift_amount is "
+            "summed without FX conversion. Normalise to one currency first.",
+            stacklevel=2,
+        )
+
+    df["_contact_id"] = df["contact_id"].astype("string").str.strip()
+    df["_ts"] = _to_datetime(df["receive_date"])
+    df["_amount"] = _to_amount(df["total_amount"]).fillna(0.0)
+    # A gift we cannot attribute to a donor, or place in time, contributes to no
+    # feature; drop it rather than let a NaT poison a donor's recency.
+    df = df[
+        df["_contact_id"].notna()
+        & (df["_contact_id"].str.len() > 0)
+        & df["_ts"].notna()
+    ]
+    if df.empty:
+        return _empty_feature_frame()
+
+    ref = _resolve_reference_date(reference_date, df["_ts"])
+
+    grouped = df.groupby("_contact_id", sort=True)
+    out = pd.DataFrame(index=grouped.size().index)
+    # Optional identity fields — carried through when the export supplies them
+    # (this is a donor-level table keyed by CRM id, not a de-identified feature
+    # store). ``.first()`` skips nulls, so a donor whose name rode in on only
+    # some rows still resolves. Absent column -> None.
+    for out_col, src in (
+        ("constituent_email", "email"),
+        ("first_name", "first_name"),
+        ("last_name", "last_name"),
+    ):
+        out[out_col] = grouped[src].first() if src in df.columns else None
+    out["total_gift_amount"] = grouped["_amount"].sum()
+    out["gift_count"] = grouped.size()
+    out["largest_gift_amount"] = grouped["_amount"].max()
+    out["first_gift_date"] = grouped["_ts"].min()
+    out["last_gift_date"] = grouped["_ts"].max()
+    out["years_active"] = (
+        (ref - out["first_gift_date"]).dt.days / DAYS_PER_YEAR
+    ).clip(lower=0.0)
+    out["recency_days"] = (ref - out["last_gift_date"]).dt.days.clip(lower=0)
+
+    # Financial Type is CiviCRM's gift classification (Donation, Member Dues,
+    # Event Fee, ...); breadth across them is the CiviCRM analogue of the
+    # UniSchema bridge's distinct_source_systems.
+    type_col = next(
+        (c for c in ("financial_type", "financial_type_id") if c in df.columns), None
+    )
+    out["distinct_financial_types"] = grouped[type_col].nunique() if type_col else 0
+
+    out.index.name = "contact_id"
+    return _coerce_schema(out)
+
+
+def read_civicrm_contributions(path: Union[str, Path]) -> pd.DataFrame:
+    """Read CiviCRM contribution export CSV(s) into one normalised frame.
+
+    Accepts either a single ``.csv`` file or a directory, which is walked
+    **recursively** and whose ``*.csv`` files are concatenated in sorted
+    relative-path order — the shape you get from keeping a folder of monthly
+    exports. Symlinks are not followed.
+
+    Every column is read as text and the headers are normalised to the APIv4
+    spelling, so ``"Total Amount"``, ``"Contact ID"`` and ``"Contribution Date"``
+    arrive as ``total_amount``, ``contact_id`` and ``receive_date``. Nothing else
+    is done to the rows: **test-mode and non-``Completed`` contributions are
+    still present**, and it is
+    :func:`civicrm_contributions_to_features` that drops them and types the
+    values. Reading is deliberately lossless so the raw export stays inspectable.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        CSV file, or a directory of them.
+
+    Returns
+    -------
+    contributions : pandas.DataFrame
+        The export as written, with normalised column names and text values.
+        A directory holding no CSV returns an empty frame.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist. Without this an absent directory falls
+        through to the single-file branch and surfaces as an opaque OSError.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"No such file or directory: {p}")
+    if p.is_dir():
+        files = [
+            f
+            for f in p.rglob("*.csv")
+            # Skip symlinks: one inside the export folder pointing outside it
+            # must not be followed and read (path-traversal hardening).
+            if f.is_file() and not f.is_symlink()
+        ]
+        if not files:
+            return pd.DataFrame()
+        # Sort by relative path so ordering is deterministic across platforms.
+        frames = [
+            _read_csv(f) for f in sorted(files, key=lambda f: f.relative_to(p).as_posix())
+        ]
+        return pd.concat(frames, ignore_index=True)
+    return _read_csv(p)
+
+
+# --------------------------------------------------------------------------- #
+# Internals
+# --------------------------------------------------------------------------- #
+def _read_csv(path: Path) -> pd.DataFrame:
+    # utf-8-sig: CiviCRM writes UTF-8, but an export round-tripped through Excel
+    # comes back with a BOM that would otherwise ride along inside the first
+    # header. dtype=str keeps a numeric-looking Contact ID from becoming an int
+    # in one file and a float in another once a blank appears.
+    df = pd.read_csv(path, dtype=str, encoding="utf-8-sig", keep_default_na=True)
+    return _normalise_headers(df)
+
+
+def _to_frame(contributions: Union[Iterable[Mapping], pd.DataFrame]) -> pd.DataFrame:
+    if isinstance(contributions, pd.DataFrame):
+        return contributions
+    return pd.DataFrame(list(contributions))
+
+
+def _canonical(header: str) -> str:
+    key = _NON_ALNUM.sub("_", str(header).strip().lower()).strip("_")
+    return _HEADER_ALIASES.get(key, key)
+
+
+def _normalise_headers(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty and df.columns.empty:
+        return df
+    out = df.rename(columns={c: _canonical(c) for c in df.columns})
+    # A wide export can carry the same field twice ("Amount" and "Total
+    # Amount"), which would collapse to two identically named columns and make
+    # df["total_amount"] a DataFrame. Keep the first.
+    return out.loc[:, ~out.columns.duplicated()]
+
+
+def _to_amount(series: pd.Series) -> pd.Series:
+    """Coerce a CiviCRM amount column to float.
+
+    ponytail: strips grouping separators and currency symbols so an
+    Excel-formatted ``"$1,250.00"`` parses. That assumes ``.`` is the decimal
+    point; a site exporting ``1.250,00`` needs normalising upstream.
+    """
+    if pd.api.types.is_numeric_dtype(series):
+        return pd.to_numeric(series, errors="coerce")
+    cleaned = series.astype("string").str.replace(r"[^\d.\-]", "", regex=True)
+    return pd.to_numeric(cleaned, errors="coerce")
+
+
+def _to_datetime(series: pd.Series) -> pd.Series:
+    """Parse CiviCRM dates to tz-naive UTC (matches the datasets' naive dates).
+
+    ponytail: CiviCRM stores ``receive_date`` as ``YYYY-MM-DD HH:MM:SS``, but a
+    CSV export writes it in the site's configured date format, so a real export
+    can carry ``03/01/2025``. ``format="mixed"`` parses both rather than
+    rejecting one; it also resolves that example as *March 1* under pandas'
+    ``dayfirst=False`` default. A site configured ``dd/mm/yyyy`` should pass an
+    already-parsed datetime column.
+    """
+    ts = pd.to_datetime(series, format="mixed", errors="coerce", utc=True)
+    return ts.dt.tz_localize(None)
+
+
+def _to_bool(series: pd.Series) -> pd.Series:
+    """CiviCRM writes is_test as 1/0 over APIv4 and as text in a CSV export."""
+    if pd.api.types.is_numeric_dtype(series) or pd.api.types.is_bool_dtype(series):
+        return series.fillna(0).astype(bool)
+    return series.astype("string").str.strip().str.casefold().isin(_TRUTHY)
+
+
+def _resolve_reference_date(
+    reference_date: Optional[Union[str, pd.Timestamp]],
+    timestamps: pd.Series,
+) -> pd.Timestamp:
+    if reference_date is None or pd.isna(reference_date):
+        return timestamps.max()
+    ref = pd.to_datetime(reference_date, utc=True)
+    return ref.tz_localize(None)
+
+
+def _empty_feature_frame() -> pd.DataFrame:
+    out = pd.DataFrame({col: pd.Series(dtype=dt) for col, dt in _FEATURE_DTYPES.items()})
+    out.index = pd.Index([], name="contact_id", dtype="object")
+    return out
+
+
+def _coerce_schema(out: pd.DataFrame) -> pd.DataFrame:
+    return out[list(_FEATURE_DTYPES)].astype(_FEATURE_DTYPES)

--- a/tests/test_civicrm.py
+++ b/tests/test_civicrm.py
@@ -1,0 +1,563 @@
+"""
+tests/test_civicrm.py
+Tests for the philanthropy.ingest CiviCRM contribution bridge.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from philanthropy.ingest import (
+    civicrm_contributions_to_features,
+    read_civicrm_contributions,
+)
+from philanthropy.ingest._civicrm import _FEATURE_DTYPES
+
+# Header labels as a CiviCRM CSV export writes them.
+_HEADER = (
+    "Contribution ID,Contact ID,Contribution Date,Total Amount,Currency,"
+    "Contribution Status,Financial Type,Test Mode,Email,First Name,Last Name"
+)
+
+
+def _row(cid, contact, date, amount, *, currency="USD", status="Completed",
+         ftype="Donation", test="0", email="", first="", last=""):
+    return (
+        f"{cid},{contact},{date},{amount},{currency},{status},{ftype},"
+        f"{test},{email},{first},{last}"
+    )
+
+
+def _export(*rows):
+    return "\n".join((_HEADER,) + rows) + "\n"
+
+
+@pytest.fixture
+def contributions():
+    """APIv4-spelled rows: two donors, one Failed gift, one test-mode gift."""
+    return [
+        {"id": "1", "contact_id": "101", "receive_date": "2025-01-15",
+         "total_amount": "250.00", "currency": "USD",
+         "contribution_status": "Completed", "financial_type": "Donation",
+         "is_test": "0", "email": "ada@uni.edu",
+         "first_name": "Ada", "last_name": "Lovelace"},
+        {"id": "2", "contact_id": "101", "receive_date": "2025-06-01",
+         "total_amount": "1000.00", "currency": "USD",
+         "contribution_status": "Completed", "financial_type": "Member Dues",
+         "is_test": "0", "email": "ada@uni.edu",
+         "first_name": "Ada", "last_name": "Lovelace"},
+        {"id": "3", "contact_id": "101", "receive_date": "2025-06-05",
+         "total_amount": "99.00", "currency": "USD",
+         "contribution_status": "Failed", "financial_type": "Donation",
+         "is_test": "0", "email": "ada@uni.edu",
+         "first_name": "Ada", "last_name": "Lovelace"},
+        {"id": "4", "contact_id": "202", "receive_date": "2025-03-01",
+         "total_amount": "5000.00", "currency": "USD",
+         "contribution_status": "Completed", "financial_type": "Donation",
+         "is_test": "1", "email": "grace@uni.edu",
+         "first_name": "Grace", "last_name": "Hopper"},
+        {"id": "5", "contact_id": "202", "receive_date": "2025-04-10",
+         "total_amount": "750.00", "currency": "USD",
+         "contribution_status": "Completed", "financial_type": "Donation",
+         "is_test": "0", "email": "grace@uni.edu",
+         "first_name": "Grace", "last_name": "Hopper"},
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation
+# --------------------------------------------------------------------------- #
+def test_returns_one_row_per_contact(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    assert list(feats.index) == ["101", "202"]
+    assert feats.index.name == "contact_id"
+
+
+def test_schema_and_dtypes(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+    for col, dtype in _FEATURE_DTYPES.items():
+        assert feats[col].dtype == np.dtype(dtype), col
+
+
+def test_monetary_and_counts(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    # 250 + 1000; the Failed row is excluded.
+    assert float(feats.loc["101", "total_gift_amount"]) == 1250.0
+    assert int(feats.loc["101", "gift_count"]) == 2
+    assert float(feats.loc["101", "largest_gift_amount"]) == 1000.0
+    # 202's 5000 gift is test-mode, so only the 750 survives.
+    assert float(feats.loc["202", "total_gift_amount"]) == 750.0
+    assert int(feats.loc["202", "gift_count"]) == 1
+
+
+def test_gift_dates(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    assert feats.loc["101", "first_gift_date"] == pd.Timestamp("2025-01-15")
+    assert feats.loc["101", "last_gift_date"] == pd.Timestamp("2025-06-01")
+
+
+def test_distinct_financial_types(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    assert int(feats.loc["101", "distinct_financial_types"]) == 2
+    assert int(feats.loc["202", "distinct_financial_types"]) == 1
+
+
+def test_financial_type_id_used_when_label_absent():
+    rows = [
+        {"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10",
+         "financial_type_id": "1"},
+        {"contact_id": "1", "receive_date": "2025-02-01", "total_amount": "10",
+         "financial_type_id": "4"},
+    ]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        feats = civicrm_contributions_to_features(rows)
+    assert int(feats.loc["1", "distinct_financial_types"]) == 2
+
+
+def test_no_financial_type_column_yields_zero():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10"}]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert int(feats.loc["1", "distinct_financial_types"]) == 0
+
+
+def test_recency_features_non_negative(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    assert (feats["recency_days"] >= 0).all()
+    assert (feats["years_active"] >= 0.0).all()
+
+
+def test_reference_date_shifts_recency(contributions):
+    early = civicrm_contributions_to_features(contributions,
+                                              reference_date="2025-06-01")
+    late = civicrm_contributions_to_features(contributions,
+                                             reference_date="2026-06-01")
+    assert int(late.loc["101", "recency_days"]) - \
+        int(early.loc["101", "recency_days"]) == 365
+
+
+def test_reference_date_nat_falls_back_to_batch_max(contributions):
+    default = civicrm_contributions_to_features(contributions)
+    nat = civicrm_contributions_to_features(contributions, reference_date=pd.NaT)
+    assert nat["recency_days"].equals(default["recency_days"])
+
+
+def test_carries_identity_fields(contributions):
+    feats = civicrm_contributions_to_features(contributions)
+    assert feats.loc["101", "constituent_email"] == "ada@uni.edu"
+    assert feats.loc["101", "first_name"] == "Ada"
+    assert feats.loc["202", "last_name"] == "Hopper"
+
+
+def test_identity_fields_absent_yields_null_column_not_crash():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10"}]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert feats.loc["1", "constituent_email"] is None
+    assert feats.loc["1", "first_name"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Status / test-mode filtering — the reason this bridge exists
+# --------------------------------------------------------------------------- #
+def test_statuses_none_counts_every_row(contributions):
+    feats = civicrm_contributions_to_features(contributions, statuses=None)
+    # The Failed 99 is now included; the test-mode row still is not.
+    assert float(feats.loc["101", "total_gift_amount"]) == 1349.0
+
+
+def test_statuses_can_select_other_statuses():
+    rows = [
+        {"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10",
+         "contribution_status": "Completed"},
+        {"contact_id": "1", "receive_date": "2025-02-01", "total_amount": "40",
+         "contribution_status": "Pending"},
+    ]
+    feats = civicrm_contributions_to_features(rows, statuses=("Completed", "Pending"))
+    assert float(feats.loc["1", "total_gift_amount"]) == 50.0
+
+
+def test_status_match_is_case_insensitive():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01",
+             "total_amount": "10", "contribution_status": " completed "}]
+    feats = civicrm_contributions_to_features(rows)
+    assert int(feats.loc["1", "gift_count"]) == 1
+
+
+def test_missing_status_column_warns():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10"}]
+    with pytest.warns(UserWarning, match="no contribution_status column"):
+        civicrm_contributions_to_features(rows)
+
+
+def test_statuses_none_does_not_warn_about_missing_status():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10"}]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        civicrm_contributions_to_features(rows, statuses=None)
+
+
+def test_numeric_is_test_column_is_dropped():
+    rows = pd.DataFrame({
+        "contact_id": ["1", "1"],
+        "receive_date": ["2025-01-01", "2025-02-01"],
+        "total_amount": [10.0, 999.0],
+        "is_test": [0, 1],
+    })
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_boolean_is_test_column_is_dropped():
+    rows = pd.DataFrame({
+        "contact_id": ["1", "1"],
+        "receive_date": ["2025-01-01", "2025-02-01"],
+        "total_amount": [10.0, 999.0],
+        "is_test": [False, True],
+    })
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_textual_test_mode_column_is_dropped():
+    rows = [
+        {"contact_id": "1", "Contribution Date": "2025-01-01",
+         "Total Amount": "10", "Test Mode": "No"},
+        {"contact_id": "1", "Contribution Date": "2025-02-01",
+         "Total Amount": "999", "Test Mode": "Yes"},
+    ]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_every_row_filtered_out_returns_typed_empty_frame():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01",
+             "total_amount": "10", "contribution_status": "Refunded"}]
+    feats = civicrm_contributions_to_features(rows)
+    assert feats.empty
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+
+
+# --------------------------------------------------------------------------- #
+# Header normalisation
+# --------------------------------------------------------------------------- #
+def test_export_labels_and_apiv4_names_agree(contributions):
+    labelled = [
+        {"Contribution ID": r["id"], "Contact ID": r["contact_id"],
+         "Contribution Date": r["receive_date"], "Total Amount": r["total_amount"],
+         "Currency": r["currency"], "Contribution Status": r["contribution_status"],
+         "Financial Type": r["financial_type"], "Test Mode": r["is_test"],
+         "Email": r["email"], "First Name": r["first_name"],
+         "Last Name": r["last_name"]}
+        for r in contributions
+    ]
+    assert civicrm_contributions_to_features(labelled).equals(
+        civicrm_contributions_to_features(contributions)
+    )
+
+
+def test_apiv4_pseudo_fields_are_recognised():
+    rows = [{
+        "contact_id": 101, "receive_date": "2025-01-15T00:00:00Z",
+        "total_amount": 250.0, "contribution_status_id:name": "Completed",
+        "financial_type_id:label": "Donation",
+    }, {
+        "contact_id": 101, "receive_date": "2025-02-15T00:00:00Z",
+        "total_amount": 40.0, "contribution_status_id:name": "Failed",
+        "financial_type_id:label": "Donation",
+    }]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        feats = civicrm_contributions_to_features(rows)
+    assert float(feats.loc["101", "total_gift_amount"]) == 250.0
+    assert int(feats.loc["101", "distinct_financial_types"]) == 1
+
+
+def test_date_received_label_is_accepted():
+    rows = [{"Contact ID": "1", "Date Received": "2025-01-01",
+             "Amount": "10", "Contribution Status": "Completed"}]
+    feats = civicrm_contributions_to_features(rows)
+    assert feats.loc["1", "first_gift_date"] == pd.Timestamp("2025-01-01")
+
+
+def test_duplicate_header_collapses_to_the_first():
+    # A wide export carrying both "Amount" and "Total Amount" must stay 1-D.
+    rows = [{"Contact ID": "1", "Receive Date": "2025-01-01",
+             "Amount": "10", "Total Amount": "999"}]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_missing_required_column_raises_keyerror():
+    rows = [{"contact_id": "1", "total_amount": "10"}]
+    with pytest.raises(KeyError, match="receive_date"):
+        civicrm_contributions_to_features(rows)
+
+
+# --------------------------------------------------------------------------- #
+# Value coercion
+# --------------------------------------------------------------------------- #
+def test_currency_formatted_amounts_parse():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01",
+             "total_amount": "$1,250.50"}]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 1250.50
+
+
+def test_numeric_amount_column_passes_through():
+    rows = pd.DataFrame({
+        "contact_id": ["1"], "receive_date": ["2025-01-01"],
+        "total_amount": [1250.5],
+    })
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 1250.5
+
+
+def test_unparseable_amount_counts_as_zero():
+    rows = [
+        {"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "n/a"},
+        {"contact_id": "1", "receive_date": "2025-02-01", "total_amount": "10"},
+    ]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+    assert int(feats.loc["1", "gift_count"]) == 2
+
+
+def test_locale_formatted_date_parses_month_first():
+    rows = [{"contact_id": "1", "receive_date": "03/01/2025", "total_amount": "10"}]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert feats.loc["1", "first_gift_date"] == pd.Timestamp("2025-03-01")
+
+
+def test_already_parsed_datetime_column_passes_through():
+    # The documented escape hatch for a dd/mm/yyyy site: hand in real datetimes.
+    rows = pd.DataFrame({
+        "contact_id": ["1"],
+        "receive_date": pd.to_datetime(["03/01/2025"], dayfirst=True),
+        "total_amount": [10.0],
+    })
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert feats.loc["1", "first_gift_date"] == pd.Timestamp("2025-01-03")
+
+
+def test_timezone_aware_datetime_column_normalises_to_naive_utc():
+    rows = pd.DataFrame({
+        "contact_id": ["1"],
+        "receive_date": pd.to_datetime(["2025-01-01 00:00:00"]).tz_localize(
+            "America/Chicago"
+        ),
+        "total_amount": [10.0],
+    })
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert feats.loc["1", "first_gift_date"] == pd.Timestamp("2025-01-01 06:00:00")
+
+
+def test_timezone_aware_dates_normalise_to_naive_utc():
+    rows = [{"contact_id": "1", "receive_date": "2025-01-01T23:00:00-05:00",
+             "total_amount": "10"}]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert feats.loc["1", "first_gift_date"] == pd.Timestamp("2025-01-02 04:00:00")
+
+
+def test_unparseable_date_row_dropped():
+    rows = [
+        {"contact_id": "1", "receive_date": "not-a-date", "total_amount": "999"},
+        {"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10"},
+    ]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert int(feats.loc["1", "gift_count"]) == 1
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_blank_contact_id_row_dropped():
+    rows = [
+        {"contact_id": "  ", "receive_date": "2025-01-01", "total_amount": "999"},
+        {"contact_id": "1", "receive_date": "2025-01-01", "total_amount": "10"},
+    ]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert list(feats.index) == ["1"]
+
+
+def test_parsing_emits_no_warning(contributions):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        civicrm_contributions_to_features(contributions)
+
+
+# --------------------------------------------------------------------------- #
+# Deduplication and currency
+# --------------------------------------------------------------------------- #
+def test_deduplicates_by_contribution_id(contributions):
+    once = civicrm_contributions_to_features(contributions)
+    twice = civicrm_contributions_to_features(contributions + contributions)
+    assert twice["total_gift_amount"].equals(once["total_gift_amount"])
+    assert twice["gift_count"].equals(once["gift_count"])
+
+
+def test_dedup_preserves_rows_without_a_contribution_id():
+    rows = [
+        {"id": "1", "contact_id": "1", "receive_date": "2025-01-01",
+         "total_amount": "10"},
+        {"contact_id": "1", "receive_date": "2025-02-01", "total_amount": "20"},
+        {"contact_id": "1", "receive_date": "2025-03-01", "total_amount": "30"},
+    ]
+    feats = civicrm_contributions_to_features(rows, statuses=None)
+    assert int(feats.loc["1", "gift_count"]) == 3
+    assert float(feats.loc["1", "total_gift_amount"]) == 60.0
+
+
+def test_mixed_currency_warns(contributions):
+    rows = contributions + [
+        {"id": "6", "contact_id": "303", "receive_date": "2025-05-01",
+         "total_amount": "100.00", "currency": "EUR",
+         "contribution_status": "Completed", "financial_type": "Donation",
+         "is_test": "0"},
+    ]
+    with pytest.warns(UserWarning, match="mixes currencies"):
+        civicrm_contributions_to_features(rows)
+
+
+def test_single_currency_does_not_warn(contributions):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        civicrm_contributions_to_features(contributions)
+
+
+# --------------------------------------------------------------------------- #
+# Empty inputs
+# --------------------------------------------------------------------------- #
+def test_empty_list_returns_typed_empty_frame():
+    feats = civicrm_contributions_to_features([])
+    assert feats.empty
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+    assert feats.index.name == "contact_id"
+    for col, dtype in _FEATURE_DTYPES.items():
+        assert feats[col].dtype == np.dtype(dtype), col
+
+
+def test_empty_dataframe_with_columns_returns_typed_empty_frame():
+    feats = civicrm_contributions_to_features(
+        pd.DataFrame(columns=["contact_id", "receive_date", "total_amount"])
+    )
+    assert feats.empty
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+
+
+# --------------------------------------------------------------------------- #
+# read_civicrm_contributions
+# --------------------------------------------------------------------------- #
+def test_read_single_csv(tmp_path):
+    f = tmp_path / "contributions.csv"
+    f.write_text(_export(
+        _row(1, 101, "2025-01-15", "250.00", email="ada@uni.edu"),
+        _row(2, 202, "2025-03-01", "5000.00", email="grace@uni.edu"),
+    ))
+    df = read_civicrm_contributions(f)
+    assert len(df) == 2
+    assert "total_amount" in df.columns and "receive_date" in df.columns
+    assert list(df["contact_id"]) == ["101", "202"]
+
+
+def test_read_is_lossless_and_features_applies_the_policy(tmp_path):
+    f = tmp_path / "contributions.csv"
+    f.write_text(_export(
+        _row(1, 101, "2025-01-15", "250.00"),
+        _row(2, 101, "2025-02-15", "99.00", status="Refunded"),
+        _row(3, 101, "2025-03-15", "999.00", test="1"),
+    ))
+    df = read_civicrm_contributions(f)
+    assert len(df) == 3, "reading must not drop rows"
+    feats = civicrm_contributions_to_features(df)
+    assert float(feats.loc["101", "total_gift_amount"]) == 250.0
+
+
+def test_read_strips_the_excel_bom(tmp_path):
+    f = tmp_path / "excel.csv"
+    f.write_text(_export(_row(1, 101, "2025-01-15", "250.00")),
+                 encoding="utf-8-sig")
+    df = read_civicrm_contributions(f)
+    assert "contact_id" in df.columns
+
+
+def test_read_directory_concatenates_in_sorted_order(tmp_path):
+    (tmp_path / "2025-02.csv").write_text(_export(
+        _row(2, 202, "2025-02-01", "20.00")))
+    (tmp_path / "2025-01.csv").write_text(_export(
+        _row(1, 101, "2025-01-01", "10.00")))
+    df = read_civicrm_contributions(tmp_path)
+    assert list(df["contact_id"]) == ["101", "202"]
+
+
+def test_read_recurses_into_subdirectories(tmp_path):
+    nested = tmp_path / "2025" / "q1"
+    nested.mkdir(parents=True)
+    (nested / "jan.csv").write_text(_export(_row(1, 101, "2025-01-01", "10.00")))
+    (tmp_path / "top.csv").write_text(_export(_row(2, 202, "2025-02-01", "20.00")))
+    df = read_civicrm_contributions(tmp_path)
+    assert set(df["contact_id"]) == {"101", "202"}
+
+
+def test_read_directory_with_no_csv_returns_empty_frame(tmp_path):
+    (tmp_path / "notes.txt").write_text("not an export")
+    df = read_civicrm_contributions(tmp_path)
+    assert df.empty
+    assert civicrm_contributions_to_features(df).empty
+
+
+def test_read_does_not_follow_symlinks(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.csv").write_text(_export(_row(9, 999, "2025-01-01", "1.00")))
+    exports = tmp_path / "exports"
+    exports.mkdir()
+    (exports / "real.csv").write_text(_export(_row(1, 101, "2025-01-01", "10.00")))
+    try:
+        (exports / "link.csv").symlink_to(outside / "secret.csv")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform-dependent
+        pytest.skip("symlinks unavailable on this platform")
+    df = read_civicrm_contributions(exports)
+    assert list(df["contact_id"]) == ["101"]
+
+
+def test_read_missing_path_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_civicrm_contributions(tmp_path / "nope.csv")
+
+
+# --------------------------------------------------------------------------- #
+# Integration: bridge output flows into an estimator
+# --------------------------------------------------------------------------- #
+def test_features_feed_donor_propensity_model():
+    from philanthropy.datasets import generate_synthetic_donor_data
+    from philanthropy.models import DonorPropensityModel
+
+    rng = np.random.default_rng(0)
+    rows = []
+    contribution_id = 0
+    for donor in range(40):
+        for gift in range(int(rng.integers(1, 5))):
+            contribution_id += 1
+            rows.append({
+                "id": str(contribution_id),
+                "contact_id": str(1000 + donor),
+                "receive_date": f"2025-0{1 + gift}-15",
+                "total_amount": f"{rng.uniform(25, 5000):.2f}",
+                "currency": "USD",
+                "contribution_status": "Completed",
+                "financial_type": "Donation",
+                "is_test": "0",
+            })
+    feats = civicrm_contributions_to_features(rows, reference_date="2026-01-01")
+
+    cols = ["total_gift_amount", "years_active", "gift_count"]
+    history = generate_synthetic_donor_data(n_samples=300, random_state=0)
+    model = DonorPropensityModel(n_estimators=25, random_state=0).fit(
+        history[["total_gift_amount", "years_active", "event_attendance_count"]]
+        .to_numpy(),
+        history["is_major_donor"].to_numpy(),
+    )
+    scores = model.predict_affinity_score(feats[cols].to_numpy())
+    assert scores.shape == (len(feats),)
+    assert np.isfinite(scores).all()


### PR DESCRIPTION
[CiviCRM](https://civicrm.org) is the CRM most small and mid-sized nonprofits actually run, and `civicrm_contribution` is where their giving history lives. Getting that table into a donor feature frame was left to every user — and a bare `pd.read_csv` gets two things wrong, both of which inflate lifetime giving:

- **Test-mode rows are real rows.** CiviCRM writes payment-processor test transactions into the same table (`is_test` / `Test Mode`). That is money nobody gave.
- **A contribution is not a payment.** `contribution_status` separates `Completed` from `Pending`, `Failed`, `Refunded`, `Cancelled` and `Chargeback`.

`philanthropy.ingest` now carries `read_civicrm_contributions` and `civicrm_contributions_to_features` (Tier 2), alongside the UniSchema bridge.

## What it does

- Test-mode rows are **always** dropped; only `Completed` is counted unless `statuses=` says otherwise. Asking for a status filter the batch cannot support **warns** rather than silently summing refunds.
- **Both spellings work.** Headers normalise to the APIv4 name, so a CSV export's labels (`Contact ID`, `Total Amount`, `Contribution Date`) and the DB columns (`contact_id`, `total_amount`, `receive_date`) take the same path — as do the APIv4 `contribution_status_id:name` and `financial_type_id:label` pseudo-fields, which an API pull would otherwise arrive with no status column at all. Labels verified against CiviCRM's own `schema/Contribute/Contribution.entityType.php`, not recalled.
- **Leakage-safe.** Recency is anchored to `reference_date` or the batch's latest gift, never a moving "now" — the same contract as the UniSchema bridge.
- **Replay-safe.** Rows sharing a contribution id are collapsed, which is exactly what overlapping monthly exports produce.
- Reading is **lossless**; all policy lives in the aggregation step, so the raw export stays inspectable.
- Amounts survive Excel formatting (`$1,250.00`); dates parse mixed, because an export writes the site's configured date format rather than the stored `YYYY-MM-DD HH:MM:SS`. Both ceilings are marked with a `ponytail:` comment and documented in the how-to.

Output is one row per `contact_id`. `recency_days`, `gift_count` and `total_gift_amount` are the R, F and M of an RFM model, so `RFMTransformer` is not needed on top of it.

## Verification

`make ci` green — flake8 clean, `mypy: Success: no issues found in 47 source files`, 27 doctests, **1680 passed / 2 skipped**, coverage **94.93%** against the 92% gate. The risk-tier floor (`philanthropy/ingest/*` is in it) reports 95% against its 93% floor.

```
philanthropy/ingest/_civicrm.py   104 stmts   34 branch   0 miss   100%
```

51 tests in `tests/test_civicrm.py`. The new how-to page is executed by `test_doc_examples.py`, so the worked example cannot rot.

## Not in this PR

`examples/civicrm_to_scores.py`. The how-to page is runnable and CI-tested; a single-file script is worth adding when there is somewhere to link it.