### PR TITLE
Fix tautological doctest and add no-leakage test for default gap_years=0

### DIFF
--- a/philanthropy/model_selection/_temporal_donor_splitter.py
+++ b/philanthropy/model_selection/_temporal_donor_splitter.py
@@ -29,7 +29,7 @@ Typical usage
 >>> len(splits)
 3
 >>> train_idx, test_idx = splits[0]
->>> bool(fiscal_years[test_idx].max() <= fiscal_years[train_idx].min() + 1 or True)
+>>> bool(fiscal_years[train_idx].max() < fiscal_years[test_idx].min())
 True
 """
 

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -74,6 +74,28 @@ def test_gap_years_withholds_the_year_before_each_test_fold():
         assert fy[train_idx].max() < test_fy - 1
 
 
+def test_default_splitter_no_leakage_gap_years_zero():
+    """Default gap_years=0: training fold never contains a FY at or after the test FY,
+    and each test fold is exactly one fiscal year."""
+    X = np.zeros((10, 2))
+    splitter = FiscalYearGroupedSplitter(n_splits=3)
+    splits = list(splitter.split(X, groups=_FY_GROUPS))
+    assert len(splits) == 3
+
+    fy = np.asarray(_FY_GROUPS)
+    train_sizes = []
+    for train_idx, test_idx in splits:
+        # No leakage: max training FY is strictly less than min test FY.
+        assert fy[train_idx].max() < fy[test_idx].min()
+        # Each test fold is exactly one fiscal year.
+        assert len(set(fy[test_idx])) == 1
+        train_sizes.append(len(train_idx))
+
+    # Expanding window: training set grows with each split.
+    assert train_sizes == sorted(train_sizes)
+    assert len(set(train_sizes)) == len(train_sizes)  # strictly increasing
+
+
 def test_not_enough_fiscal_years_names_the_shortfall():
     X = np.zeros((10, 2))
     with pytest.raises(


### PR DESCRIPTION
## Summary

Fixes the tautological doctest in `_temporal_donor_splitter.py` (line 32 used `or True`, making the assertion impossible to fail) and adds a proper no-leakage test for the default `gap_years=0` config — which previously had its guarantee only in a docstring, not the test suite.

Fixes #26

## Changes

**Doctest fix** (1 line):
```python
# Before (tautology — always True regardless of data):
>>> bool(fiscal_years[test_idx].max() <= fiscal_years[train_idx].min() + 1 or True)

# After (real property — fails if leakage occurs):
>>> bool(fiscal_years[train_idx].max() < fiscal_years[test_idx].min())
```

**New test**: `test_default_splitter_no_leakage_gap_years_zero` — covers `gap_years=0` (the default, which every user gets) and asserts:
- `fy[train_idx].max() < fy[test_idx].min()` — no future fiscal year in training
- `len(set(fy[test_idx])) == 1` — each test fold is exactly one fiscal year
- Expanding window: `train_sizes` strictly increases across splits

## Verification

```
$ python -m pytest philanthropy/model_selection/_temporal_donor_splitter.py --doctest-modules -q --no-cov
2 passed

$ python -m pytest tests/test_model_selection.py -q --no-cov
11 passed  (was 10)

$ ! grep -q 'or True' philanthropy/model_selection/_temporal_donor_splitter.py && echo OK
OK
```
