### PR TITLE
chore: add page numbers to the ICCED 2025 reference in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -45,4 +45,5 @@ references:
       name: IEEE
     year: 2025
     doi: "10.1109/ICCED68324.2025.11325064"
-    # Start/end page numbers pending — add from the IEEE Xplore citation export.
+    start: 1
+    end: 5


### PR DESCRIPTION
Closes #6.

The `references` entry for the ICCED 2025 paper (DOI `10.1109/ICCED68324.2025.11325064`) carried a TODO for start/end pages pending the IEEE Xplore citation export. The publisher-deposited Crossref record already has them:

```
$ curl -s https://api.crossref.org/works/10.1109/ICCED68324.2025.11325064
... "page":"1-5" ...
```

So this adds `start: 1` / `end: 5` and drops the TODO comment — no paywalled export needed.

Validated:

```
$ uvx cffconvert --validate
Citation metadata are valid according to schema version 1.2.0.
```

Out of scope: the prose citation in `README.md` still omits `pp. 1-5`.