### PR TITLE
docs: add CONTRIBUTORS.md and credit the first external contribution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,4 @@
 - [ ] New/changed public API has docstrings and is exported in the subpackage `__init__.py`
 - [ ] Tests added or updated
 - [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] Added yourself to `CONTRIBUTORS.md` (skip if you would rather not be listed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- `FiscalYearGroupedSplitter`'s module doctest asserted
+  `... <= ... + 1 or True`, which passes for every possible input and so proved
+  nothing about the split. It now asserts what the class actually promises —
+  `fiscal_years[train_idx].max() < fiscal_years[test_idx].min()` — and a new
+  `test_default_splitter_no_leakage_gap_years_zero` covers the default
+  `gap_years=0` path, which had no leakage test at all. Thanks to
+  [@fuleinist](https://github.com/fuleinist) (Chris Chen) for the first external
+  contribution ([#30](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/30),
+  closes [#26](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/26)).
+
 ### Added
 - **CiviCRM contribution bridge** — `philanthropy.ingest.read_civicrm_contributions`
   and `civicrm_contributions_to_features` (Tier 2). Turns a CiviCRM contribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,9 @@ git push origin my-change        # your fork, not upstream
 Then open a pull request against `PhilanthroPy-Project/PhilanthroPy` `main`.
 GitHub offers the button on your fork right after the push. Fill in the
 [PR template](.github/PULL_REQUEST_TEMPLATE.md): what changed and why, and add a
-`CHANGELOG.md` entry under `[Unreleased]`.
+`CHANGELOG.md` entry under `[Unreleased]`. Add yourself to
+[CONTRIBUTORS.md](CONTRIBUTORS.md) in the same PR — one line, name or handle and
+what you did.
 
 CI runs on pull requests from forks. If a job fails, push another commit to the
 same branch — the PR updates itself.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,26 @@
+# Contributors
+
+Everyone who has landed a change in PhilanthroPy, in order of first
+contribution. Code, docs, tests, and review all count.
+
+## Maintainer
+
+- **Shivam Lalakiya** ([@shivamlalakiya](https://github.com/shivamlalakiya)) —
+  author and maintainer.
+
+## Contributors
+
+- **Chris Chen** ([@fuleinist](https://github.com/fuleinist)) — replaced a
+  tautological doctest in `FiscalYearGroupedSplitter` with one that can actually
+  fail, and added the missing no-leakage test for the default `gap_years=0`
+  ([#30](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/30)).
+
+## Getting listed
+
+Add yourself here in the same pull request as your change — one line, your name
+or handle and what you did. If you would rather not be listed, that is fine
+too; say so in the PR and it stays out.
+
+Not sure where to start? See
+[CONTRIBUTING.md](CONTRIBUTING.md) and the
+[good first issues](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE README.md CHANGELOG.md CITATION.cff
+include LICENSE README.md CHANGELOG.md CONTRIBUTORS.md CITATION.cff
 recursive-include philanthropy/datasets/data *.csv
 
 prune tests

--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ local test gate, and pre-push hook setup. In short: fork, branch, run `make ci`
 before every push, and never use `git push --no-verify`. Setup plus a first green
 `make ci` takes about eight minutes.
 
+Everyone who has landed a change is credited in
+[CONTRIBUTORS.md](CONTRIBUTORS.md) — add yourself in the same PR.
+
 Questions are welcome in
 [Discussions](https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,6 +24,10 @@ runs on top of it — is in
 
 Setup plus a first green `make ci` takes about eight minutes.
 
+Everyone who has landed a change is credited in
+[CONTRIBUTORS.md](https://github.com/PhilanthroPy-Project/PhilanthroPy/blob/main/CONTRIBUTORS.md)
+— add yourself in the same pull request.
+
 ## Questions
 
 Ask in


### PR DESCRIPTION
## What & why

The first external contribution ([#30](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/30), Chris Chen / @fuleinist) is recorded only in the git log — there is no file a reader, or a pyOpenSci/MLOSS reviewer, can look at to see that this project has contributors. #30 also merged without the `CHANGELOG.md` entry the PR template asks for.

- **`CONTRIBUTORS.md`** (new) — maintainer, contributors with what each one did, and how to get listed. One file rather than both `AUTHORS.md` and `CONTRIBUTORS.md`: two lists of the same people drift apart, and `AUTHORS` conventionally implies copyright holders, which `LICENSE` states as a single name. Includes an opt-out line.
- **`CHANGELOG.md`** — the missing `[Unreleased]` / `Fixed` entry for #30, describing what the tautological doctest actually failed to check.
- Links from `README.md`, `CONTRIBUTING.md`, and `docs/contributing.md`; a checklist line in the PR template; `CONTRIBUTORS.md` added to `MANIFEST.in` so it ships in the sdist.

Docs only — no source changes.

## Checklist
- [x] `make ci` passes locally (docs-only change; `tests/test_doc_examples.py` is the suite that reads `README.md` and `docs/**.md` — 16 passed)
- [x] New/changed public API has docstrings and is exported in the subpackage `__init__.py` — n/a, no API change
- [x] Tests added or updated — n/a, no code change
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Added yourself to `CONTRIBUTORS.md`