### PR TITLE
docs: document preprocessing feature names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- Added complete output-column documentation to all eleven preprocessing
+  `get_feature_names_out` overrides that previously rendered blank in the API
+  reference.
+
 ### Fixed
 - `FiscalYearGroupedSplitter`'s module doctest asserted
   `... <= ... + 1 or True`, which passes for every possible input and so proved

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,8 @@ contribution. Code, docs, tests, and review all count.
   tautological doctest in `FiscalYearGroupedSplitter` with one that can actually
   fail, and added the missing no-leakage test for the default `gap_years=0`
   ([#30](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/30)).
+- [@BortnikMaxim](https://github.com/BortnikMaxim) — documented the output-column
+  contracts of the preprocessing transformers' `get_feature_names_out` methods.
 
 ## Getting listed
 

--- a/philanthropy/preprocessing/_encounters.py
+++ b/philanthropy/preprocessing/_encounters.py
@@ -409,6 +409,25 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         return X_out.to_numpy(dtype=np.float64)
 
     def get_feature_names_out(self, input_features=None):
+        """Return privacy-filtered donor and generated encounter feature names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored. Names are derived from the columns recorded by :meth:`fit`.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            Fitted input columns excluding detected PII and ``gift_date_col``,
+            followed by ``"days_since_last_discharge"`` and
+            ``"encounter_frequency_score"``.
+
+        Raises
+        ------
+        NotFittedError
+            If the transformer has not been fitted.
+        """
         check_is_fitted(self)
         features = list(self.feature_names_in_)
         dropped = set(self._identify_pii_columns(self.feature_names_in_))
@@ -422,4 +441,3 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
         return tags
-

--- a/philanthropy/preprocessing/_grateful_patient.py
+++ b/philanthropy/preprocessing/_grateful_patient.py
@@ -355,6 +355,24 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
         return result.to_numpy(dtype=np.float64)
 
     def get_feature_names_out(self, input_features=None):
+        """Return the generated grateful-patient feature names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored because the featurizer always emits the same four features.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["clinical_gravity_score", "distinct_service_lines",
+            "distinct_physicians", "total_drg_weight"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the featurizer has not been fitted.
+        """
         check_is_fitted(self)
         return np.array(
             [

--- a/philanthropy/preprocessing/_matching_gift.py
+++ b/philanthropy/preprocessing/_matching_gift.py
@@ -204,6 +204,24 @@ class MatchingGiftFeaturizer(TransformerMixin, BaseEstimator):
         )
 
     def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        """Return the generated matching-gift feature names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored because the featurizer always emits the same three features.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["has_employer", "match_ratio",
+            "potential_matched_amount"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the featurizer has not been fitted.
+        """
         check_is_fitted(self)
         return np.array(
             ["has_employer", "match_ratio", "potential_matched_amount"],

--- a/philanthropy/preprocessing/_planned_giving.py
+++ b/philanthropy/preprocessing/_planned_giving.py
@@ -193,6 +193,24 @@ class PlannedGivingSignalTransformer(TransformerMixin, BaseEstimator):
         )
 
     def get_feature_names_out(self, input_features=None):
+        """Return the generated planned-giving signal names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored because the transformer always emits the same four features.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["is_legacy_age", "is_loyal_donor", "inclination_score",
+            "composite_score"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the transformer has not been fitted.
+        """
         check_is_fitted(self)
         return np.array(
             ["is_legacy_age", "is_loyal_donor", "inclination_score", "composite_score"],

--- a/philanthropy/preprocessing/_rfm.py
+++ b/philanthropy/preprocessing/_rfm.py
@@ -92,6 +92,23 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
             raise ValueError(f"X must contain columns: {required_cols}")
 
     def get_feature_names_out(self, input_features=None):
+        """Return the donor identifier and generated RFM feature names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored because the transformer always emits the same four columns.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["donor_id", "recency", "frequency", "monetary"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the transformer has not been fitted.
+        """
         check_is_fitted(self)
         return np.array(['donor_id', 'recency', 'frequency', 'monetary'], dtype=object)
 

--- a/philanthropy/preprocessing/_share_of_wallet.py
+++ b/philanthropy/preprocessing/_share_of_wallet.py
@@ -276,6 +276,25 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
         return X_out
 
     def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        """Return imputed feature names and optional missingness indicators.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names to use. When omitted, fitted names are used, or
+            ``x0``, ``x1``, ... for unnamed input.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            Base feature names, followed by ``<column>__was_missing`` for each
+            imputed column when ``add_indicator=True``.
+
+        Raises
+        ------
+        NotFittedError
+            If the imputer has not been fitted.
+        """
         check_is_fitted(self)
         if input_features is not None:
             base = list(input_features)
@@ -484,6 +503,23 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         return np.column_stack([sow, tiers])
 
     def get_feature_names_out(self, input_features=None) -> np.ndarray:
+        """Return the share-of-wallet score and encoded tier names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored because the scorer always emits the same two features.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["sow_score", "capacity_tier"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the scorer has not been fitted.
+        """
         check_is_fitted(self)
         return np.array(["sow_score", "capacity_tier"], dtype=object)
 

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -130,6 +130,24 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         return X_df.to_numpy()
 
     def get_feature_names_out(self, input_features=None):
+        """Return the CRM columns learned during fitting.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored. The output names are the input column names recorded by
+            :meth:`fit`.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            The original CRM column names, in input order.
+
+        Raises
+        ------
+        NotFittedError
+            If the transformer has not been fitted.
+        """
         check_is_fitted(self)
         names = list(self.feature_names_in_)
         return np.array(names, dtype=object)
@@ -199,6 +217,23 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         return out_df.to_numpy()
 
     def get_feature_names_out(self, input_features=None):
+        """Return the two generated fiscal-period feature names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored because the transformer always emits the same two features.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["fiscal_year", "fiscal_quarter"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the transformer has not been fitted.
+        """
         check_is_fitted(self)
         return np.array(["fiscal_year", "fiscal_quarter"], dtype=object)
 

--- a/philanthropy/preprocessing/_wealth.py
+++ b/philanthropy/preprocessing/_wealth.py
@@ -308,6 +308,25 @@ class WealthScreeningImputer(TransformerMixin, BaseEstimator):
         return X_out
 
     def get_feature_names_out(self, input_features=None):
+        """Return imputed feature names and optional missingness indicators.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Input feature names to use. When omitted, fitted names are used, or
+            ``x0``, ``x1``, ... for unnamed input.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            Base feature names, followed by ``<column>__was_missing`` for each
+            imputed column when ``add_indicator=True``.
+
+        Raises
+        ------
+        NotFittedError
+            If the imputer has not been fitted.
+        """
         check_is_fitted(self)
         if input_features is not None:
             out = list(input_features)
@@ -326,4 +345,3 @@ class WealthScreeningImputer(TransformerMixin, BaseEstimator):
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags
-

--- a/philanthropy/preprocessing/_wealth_percentile.py
+++ b/philanthropy/preprocessing/_wealth_percentile.py
@@ -73,6 +73,24 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         return X_final.to_numpy(dtype=np.float64)
 
     def get_feature_names_out(self, input_features=None):
+        """Return input names followed by generated wealth-percentile names.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored. Names are derived from the columns recorded by :meth:`fit`.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            Fitted input names followed by ``<column><output_suffix>`` for each
+            selected wealth column.
+
+        Raises
+        ------
+        NotFittedError
+            If the transformer has not been fitted.
+        """
         check_is_fitted(self)
         out = list(self.feature_names_in_)
         for col in self.imputed_cols_:


### PR DESCRIPTION
## What & why

Documents all eleven previously blank `get_feature_names_out` overrides in `philanthropy.preprocessing`. Each NumPy-style docstring now states how `input_features` is handled, the exact fixed columns or dynamic naming rule, and the `NotFittedError` contract. This makes the generated API reference useful without changing runtime behavior.

Also updates the changelog and contributor list as required by the contribution guide.

Closes #31

## Checklist

- [x] `make ci` passes locally (1661 passed, 22 skipped; 94.5% coverage)
- [x] New/changed public API has docstrings and remains exported
- [x] Tests added or updated (not applicable: documentation-only; existing doctests and full suite pass)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Added myself to `CONTRIBUTORS.md`