### PR TITLE
docs: document fit and transform on preprocessing transformers

### DIFF
--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -89,6 +89,25 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         self.fiscal_year_start = fiscal_year_start
 
     def fit(self, X, y=None) -> "CRMCleaner":
+        """Validate configuration and input without learning state.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training-set feature matrix.
+        y : ignored
+            Present for scikit-learn API compatibility.
+
+        Returns
+        -------
+        self : CRMCleaner
+            Fitted transformer. This transformer is stateless.
+
+        Raises
+        ------
+        ValueError
+            If ``fiscal_year_start`` is invalid or ``X`` contains complex data.
+        """
         validate_fiscal_year_start(self.fiscal_year_start)
         
         # Try standard validation, fallback to object for mixed-type DataFrames or promotion errors
@@ -106,6 +125,25 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X) -> np.ndarray | pd.DataFrame:
+        """Clean CRM dates and amounts using the fitted column configuration.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix (training or held-out).
+
+        Returns
+        -------
+        X_out : np.ndarray or pd.DataFrame
+            Cleaned feature matrix. The return type mirrors the input type.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        ValueError
+            If ``X`` contains complex data.
+        """
         check_is_fitted(self)
         try:
             X_arr = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=False)
@@ -167,6 +205,25 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         self.fiscal_year_start = fiscal_year_start
 
     def fit(self, X, y=None) -> "FiscalYearTransformer":
+        """Validate configuration and input without learning state.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training-set feature matrix.
+        y : ignored
+            Present for scikit-learn API compatibility.
+
+        Returns
+        -------
+        self : FiscalYearTransformer
+            Fitted transformer. This transformer is stateless.
+
+        Raises
+        ------
+        ValueError
+            If ``fiscal_year_start`` is invalid or ``X`` contains complex data.
+        """
         validate_fiscal_year_start(self.fiscal_year_start)
         try:
             X_validated = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
@@ -181,6 +238,26 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X) -> np.ndarray | pd.DataFrame:
+        """Append fiscal year and quarter columns.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix (training or held-out).
+
+        Returns
+        -------
+        X_out : np.ndarray or pd.DataFrame
+            Feature matrix with ``fiscal_year`` and ``fiscal_quarter`` columns
+            appended. The return type mirrors the input type.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        ValueError
+            If ``X`` contains complex data.
+        """
         check_is_fitted(self)
         try:
             X_arr = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=False)

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -135,7 +135,9 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         Returns
         -------
         X_out : np.ndarray or pd.DataFrame
-            Cleaned feature matrix. The return type mirrors the input type.
+            Cleaned feature matrix. Returns a DataFrame when the transformer is
+            configured with ``set_output(transform="pandas")``, otherwise an
+            ndarray.
 
         Raises
         ------
@@ -249,7 +251,8 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         -------
         X_out : np.ndarray or pd.DataFrame
             Feature matrix with ``fiscal_year`` and ``fiscal_quarter`` columns
-            appended. The return type mirrors the input type.
+            appended. Returns a DataFrame when the transformer is configured
+            with ``set_output(transform="pandas")``, otherwise an ndarray.
 
         Raises
         ------

--- a/philanthropy/preprocessing/_wealth_percentile.py
+++ b/philanthropy/preprocessing/_wealth_percentile.py
@@ -20,6 +20,27 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         self.output_suffix = output_suffix
 
     def fit(self, X, y=None):
+        """Learn the training wealth distribution.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training-set feature matrix.
+        y : ignored
+            Present for scikit-learn API compatibility.
+
+        Returns
+        -------
+        self : WealthPercentileTransformer
+            Fitted transformer. Freezes ``feature_names_in_``,
+            ``imputed_cols_``, and ``percentile_lookup_``.
+
+        Notes
+        -----
+        ``percentile_lookup_`` stores the sorted training values per wealth
+        column. :meth:`transform` ranks held-out data against this frozen
+        training distribution, not against the batch being transformed.
+        """
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=True)
         
         if hasattr(X, "columns"):
@@ -50,6 +71,28 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
+        """Rank features against the fitted training distribution.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix (training or held-out).
+
+        Returns
+        -------
+        X_out : np.ndarray of float64
+            Numeric feature matrix with wealth percentile columns appended.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+
+        Notes
+        -----
+        Percentiles are relative to the training cohort captured by
+        ``percentile_lookup_``, which is the leakage-safety guarantee.
+        """
         check_is_fitted(self, "percentile_lookup_")
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         X_out = pd.DataFrame(X, columns=self.feature_names_in_)


### PR DESCRIPTION
Closes #33.

Adds NumPy-style docstrings to `fit` and `transform` on:
- `CRMCleaner`
- `FiscalYearTransformer`
- `WealthPercentileTransformer`

The docstrings describe frozen state, return types, and raised errors. `WealthPercentileTransformer` documents that percentiles are relative to the frozen training distribution in `percentile_lookup_`.

Verified:
- missing-docstring check prints `MISSING: none` then `OK`
- `pytest --doctest-modules philanthropy` passes (27)
- `pytest tests/test_preprocessing.py tests/test_leakage.py` passes (49)