### PR TITLE
docs: fix develop and test commands

### DIFF
--- a/docs/how-to/develop_and_test.md
+++ b/docs/how-to/develop_and_test.md
@@ -2,6 +2,8 @@
 
 Run the test suite before you propose a change. These are the same checks that run in GitHub CI, so passing them locally means your work is ready to review. The suite guards the reliability of the donor analytics models.
 
+The single command that runs everything below is `make ci`. The sections here are for running one piece at a time.
+
 ## Prerequisites
 
 Install the development dependencies:
@@ -16,10 +18,10 @@ The suite uses `pytest`, with `hypothesis` for property-based testing and `pytes
 
 ### 1. High-Level Unit Tests & Coverage
 
-Run the core suite and confirm coverage stays above 85%:
+Run the core suite; the 92% coverage gate in `pyproject.toml` is enforced automatically:
 
 ```bash
-pytest tests/ --cov=philanthropy --cov-fail-under=85
+pytest tests/ --cov=philanthropy
 ```
 
 ### 2. Scikit-Learn API Compliance
@@ -27,7 +29,7 @@ pytest tests/ --cov=philanthropy --cov-fail-under=85
 Confirm every transformer and estimator adheres to the scikit-learn API:
 
 ```bash
-pytest tests/test_sklearn_compat.py -v
+pytest tests/test_sklearn_compliance.py -v
 ```
 
 ### 3. Property-Based Testing
@@ -35,7 +37,7 @@ pytest tests/test_sklearn_compat.py -v
 Check the transformers against randomized data:
 
 ```bash
-pytest tests/test_transformers_property.py -v --hypothesis-seed=12345
+pytest tests/test_properties.py -v --hypothesis-seed=12345
 ```
 
 ### 4. Running Doctests


### PR DESCRIPTION
Closes #22.

- Points to `tests/test_sklearn_compliance.py` instead of the nonexistent `test_sklearn_compat.py`.
- Points to `tests/test_properties.py` instead of the nonexistent `test_transformers_property.py`.
- Removes the stale `--cov-fail-under=85` override; pytest-cov now uses the 92% gate from `pyproject.toml`.
- Adds the `make ci` note at the top.

Verified:
- grep finds no `85|test_sklearn_compat|test_transformers_property`
- `test_sklearn_compliance.py`: 944 passed
- `test_properties.py` with seed 12345: 18 passed