### PR TITLE
test: cover transform-time input guards

### DIFF
--- a/tests/test_matching_gift.py
+++ b/tests/test_matching_gift.py
@@ -135,6 +135,11 @@ def test_non_dataframe_raises(ratios):
         feat.fit([[1, 2], [3, 4]])
 
 
+def test_transform_non_dataframe_raises(fitted):
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        fitted.transform(np.array([[1.0, 2.0]]))
+
+
 def test_missing_columns_raises():
     feat = MatchingGiftFeaturizer()
     with pytest.raises(ValueError, match="missing required columns"):

--- a/tests/test_share_of_wallet.py
+++ b/tests/test_share_of_wallet.py
@@ -353,6 +353,16 @@ def test_share_of_wallet_scorer_negative_capacity_col_idx_raises():
         ShareOfWalletScorer(capacity_col_idx=-1).fit(np.ones((5, 2)))
 
 
+def test_share_of_wallet_scorer_capacity_col_idx_out_of_range_raises_at_transform():
+    # fit accepts an out-of-range index; the bound is enforced in transform.
+    scorer = ShareOfWalletScorer(capacity_col_idx=5).fit(np.ones((6, 3)))
+    with pytest.raises(
+        ValueError,
+        match=r"`capacity_col_idx` \(5\) exceeds number of columns \(3\)",
+    ):
+        scorer.transform(np.ones((6, 3)))
+
+
 def test_share_of_wallet_scorer_tier_labels_are_exact():
     # The old assertion was an `or` over all three labels, so it could not fail.
     X = np.array([[100.0, 100.0], [10.0, 1_000_000.0], [50.0, 100.0]])


### PR DESCRIPTION
Closes #23.

Adds the two missing transform-time guard tests:
- `MatchingGiftFeaturizer.transform` rejects non-DataFrame input.
- `ShareOfWalletScorer.transform` rejects an out-of-range `capacity_col_idx`.

Verified: `pytest tests/test_matching_gift.py tests/test_share_of_wallet.py -q -o addopts=''` passes (55 tests). Local coverage runs hit a numpy import conflict in this environment; CI coverage should cover the new lines.