### PR TITLE
docs: add make_donor_dataset docstring

### DIFF
--- a/philanthropy/utils/_testing.py
+++ b/philanthropy/utils/_testing.py
@@ -17,6 +17,57 @@ def make_donor_dataset(
     major_gift_threshold: float = 10_000.0,
     random_state: Optional[int] = 42,
 ) -> pd.DataFrame:
+    """Generate a synthetic, seeded gift-level donor dataset.
+
+    Parameters
+    ----------
+    n_donors : int, default=200
+        Number of synthetic donors to generate.
+    fiscal_year_start : int, default=7
+        Reserved. Accepted for signature stability but not currently used
+        when generating gift dates.
+    start_year : int, default=2018
+        Earliest calendar year used when sampling gift dates.
+    end_year : int, default=2024
+        Latest calendar year used when sampling gift dates.
+    lapse_rate : float, default=0.25
+        Reserved. Accepted for signature stability but not currently used
+        when generating gift dates.
+    major_gift_threshold : float, default=10_000.0
+        Gift amount (inclusive) that marks a row as a major gift.
+    random_state : int or None, default=42
+        Seed for the NumPy random-number generator. Pass an integer to
+        obtain a reproducible dataset; ``None`` draws a fresh seed every call.
+
+    Returns
+    -------
+    df : pd.DataFrame
+        A gift-level DataFrame, not a donor-level DataFrame: each donor
+        contributes 1-5 gift rows, so ``len(df) > n_donors``. Rows are sorted
+        by ``gift_date`` and the index is reset. Columns:
+
+        ``donor_id`` : str
+            Zero-padded donor id, e.g. ``D00001``.
+        ``gift_date`` : datetime64[ns]
+            Sampled between ``start_year`` and ``end_year``.
+        ``gift_amount`` : float
+            Log-normal gift amount, rounded to two decimal places.
+        ``appeal_code`` : str
+            One of ``ANNUAL``, ``MAJOR``, ``PLANNED``, ``ONLINE``, or ``EVENT``.
+        ``is_major_gift`` : bool
+            True when ``gift_amount >= major_gift_threshold``.
+
+    Examples
+    --------
+    >>> from philanthropy.utils import make_donor_dataset
+    >>> df = make_donor_dataset(n_donors=5, random_state=0)
+    >>> df.shape
+    (15, 5)
+    >>> list(df.columns)
+    ['donor_id', 'gift_date', 'gift_amount', 'appeal_code', 'is_major_gift']
+    >>> df['donor_id'].nunique()
+    5
+    """
     rng = np.random.default_rng(random_state)
     donor_ids = [f"D{str(i).zfill(5)}" for i in range(1, n_donors + 1)]
     records = []


### PR DESCRIPTION
Closes #25.

Adds a numpydoc docstring to `make_donor_dataset` documenting all parameters, the gift-level DataFrame schema, and a runnable example. `fiscal_year_start` and `lapse_rate` are documented as reserved/currently unused parameters, as noted in the issue.

Verified:
- docstring assertion passes
- `pytest philanthropy/utils/_testing.py --doctest-modules -o addopts=''` passes