### PR TITLE
docs: document model estimator methods

### DIFF
--- a/philanthropy/models/_moves.py
+++ b/philanthropy/models/_moves.py
@@ -27,6 +27,27 @@ class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
         self.random_state = random_state
 
     def fit(self, X, y):
+        """Fit the classifier to labelled moves-stage data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+        y : array-like of shape (n_samples,)
+            Moves-stage target labels.
+
+        Returns
+        -------
+        self : MovesManagementClassifier
+            Fitted estimator. Sets ``feature_names_in_`` when ``X`` is a
+            DataFrame, ``n_features_in_``, ``label_encoder_``, ``classes_``,
+            ``estimator_``, and ``n_iter_``.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` is not a classification target.
+        """
         X, y = validate_data(self, X, y, reset=True)
         # Reject continuous targets: this is a classifier, so a regression
         # target must not be silently label-encoded into pseudo-classes.
@@ -52,12 +73,46 @@ class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
         return self
 
     def predict(self, X):
+        """Predict the next moves-management stage for each donor.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted stage labels.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         y_pred = self.estimator_.predict(X)
         return self.label_encoder_.inverse_transform(y_pred)
 
     def predict_proba(self, X):
+        """Return class probabilities for each moves-management stage.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Predicted probabilities for each stage.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict_proba(X)

--- a/philanthropy/models/_planned_giving.py
+++ b/philanthropy/models/_planned_giving.py
@@ -37,6 +37,21 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
         self.random_state = random_state
 
     def fit(self, X, y) -> "PlannedGivingIntentScorer":
+        """Fit the calibrated classifier to planned-giving intent labels.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+        y : array-like of shape (n_samples,)
+            Binary target labels.
+
+        Returns
+        -------
+        self : PlannedGivingIntentScorer
+            Fitted estimator. Sets ``classes_``, ``n_features_in_``, and
+            ``estimator_``.
+        """
         X, y = validate_data(self, X, y, reset=True)
         
         self.classes_ = np.unique(y)
@@ -55,11 +70,45 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
         return self
 
     def predict(self, X) -> np.ndarray:
+        """Predict bequest/planned-giving intent labels.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict(X)
 
     def predict_proba(self, X) -> np.ndarray:
+        """Return calibrated class probabilities.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, n_classes)
+            Predicted probabilities for each class.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict_proba(X)

--- a/philanthropy/models/_propensity.py
+++ b/philanthropy/models/_propensity.py
@@ -371,6 +371,22 @@ class MajorGiftClassifier(ClassifierMixin, BaseEstimator):
         self.random_state = random_state
 
     def fit(self, X, y):
+        """Fit the classifier to labelled donor data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix. Missing values are accepted.
+        y : array-like of shape (n_samples,)
+            Binary target vector. ``1`` indicates a major-gift prospect.
+
+        Returns
+        -------
+        self : MajorGiftClassifier
+            Fitted estimator. Sets ``classes_``, ``n_features_in_``,
+            ``estimator_``, and ``n_iter_`` (the mean boosting iterations
+            across the calibration folds).
+        """
         X, y = validate_data(self, X, y, ensure_all_finite="allow-nan", reset=True)
         self.classes_ = unique_labels(y)
         self.n_features_in_ = X.shape[1]
@@ -390,15 +406,68 @@ class MajorGiftClassifier(ClassifierMixin, BaseEstimator):
         return self
 
     def predict(self, X):
+        """Predict binary major-donor labels.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix with the same columns used in :meth:`fit`.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted class labels (``0`` or ``1``).
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict(X)
 
     def predict_proba(self, X):
+        """Return calibrated class probabilities.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, 2)
+            Columns are ``[P(class=0), P(class=1)]``. The second column is
+            the calibrated major-donor probability.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict_proba(X)
 
     def predict_affinity_score(self, X):
+        """Map the calibrated major-donor probability to a 0-100 score.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        scores : ndarray of shape (n_samples,)
+            Positive-class probability multiplied by 100 and rounded to two
+            decimal places. Class ``1`` is treated as the positive class.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         proba_positive = self.predict_proba(X)[:, 1]
         return np.round(proba_positive * 100.0, 2)

--- a/philanthropy/models/_propensity_baseline.py
+++ b/philanthropy/models/_propensity_baseline.py
@@ -40,6 +40,25 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         self.threshold = threshold
 
     def fit(self, X, y):
+        """Validate input and record the target classes.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+        y : array-like of shape (n_samples,)
+            Binary target labels.
+
+        Returns
+        -------
+        self : PropensityScorer
+            Fitted estimator. Sets ``classes_``.
+
+        Raises
+        ------
+        ValueError
+            If ``y`` is not binary.
+        """
         X, y = validate_data(self, X, y, reset=True)
         check_classification_targets(y)
         y_type = type_of_target(y, input_name="y", raise_unknown=True)
@@ -52,6 +71,25 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         return self
 
     def predict(self, X):
+        """Predict binary labels using the constant probability baseline.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        y_pred : ndarray of shape (n_samples,)
+            Predicted labels. With the default threshold, the constant 0.5
+            probability is not above the threshold and ``classes_[0]`` is
+            returned for every row.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         if len(self.classes_) == 1:
@@ -61,6 +99,24 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         return self.classes_[idx]
 
     def predict_proba(self, X):
+        """Return the constant probability baseline.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Feature matrix.
+
+        Returns
+        -------
+        proba : ndarray of shape (n_samples, 2)
+            ``[0.5, 0.5]`` for every row, or shape ``(n_samples, 1)`` when
+            only one class was seen during fitting.
+
+        Raises
+        ------
+        sklearn.exceptions.NotFittedError
+            If :meth:`fit` has not been called yet.
+        """
         check_is_fitted(self)
         X = validate_data(self, X, reset=False)
         n = X.shape[0]


### PR DESCRIPTION
Closes #32.

Adds NumPy-style docstrings to `fit`, `predict`, and `predict_proba` on:
- `MajorGiftClassifier` (plus `predict_affinity_score`)
- `MovesManagementClassifier`
- `PlannedGivingIntentScorer`
- `PropensityScorer`

Verified:
- missing-docstring check prints `MISSING: none` then `OK`
- doctests: 28 passed
- model tests: 58 passed