### PR TITLE
docs: add missing docstrings to UpliftTLearner and cli.main

### DIFF
--- a/philanthropy/cli.py
+++ b/philanthropy/cli.py
@@ -217,6 +217,13 @@ def _build_parser():
 
 
 def main(argv=None):
+    """Execute the philanthropy command-line interface.
+
+    Parameters
+    ----------
+    argv : list of str, optional
+        Command-line arguments passed to the parser. If None, defaults to sys.argv[1:].
+    """
     args = _build_parser().parse_args(argv)
     args.func(args)
 

--- a/philanthropy/experimental/_uplift.py
+++ b/philanthropy/experimental/_uplift.py
@@ -190,5 +190,15 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
 
         Convenience wrapper: ``(predict_uplift_score(X) > 0).astype(int)``.
         A ``1`` marks a donor worth soliciting (positive expected uplift).
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Donor feature matrix.
+
+        Returns
+        -------
+        y : ndarray of shape (n_samples,)
+            Binary predictions (1 or 0).
         """
         return (self.predict_uplift_score(X) > 0).astype(int)


### PR DESCRIPTION
Resolves #58

**What changed:** Added comprehensive NumPy-style docstrings to the `UpliftTLearner.predict` method and the `cli.main` function.
**Why:** To ensure the API documentation is complete and consistent with the rest of the module, making it easier for developers to understand the required arguments and return types.