### PR TITLE
docs: add Raises section to five metrics functions

### DIFF
--- a/philanthropy/metrics/_concentration.py
+++ b/philanthropy/metrics/_concentration.py
@@ -42,6 +42,11 @@ def gift_concentration_gini(amounts: Collection) -> float:
     float
         Gini coefficient in ``[0.0, 1.0]``. Returns ``0.0`` for an empty input
         or an all-zero total (no distribution to measure).
+
+    Raises
+    ------
+    ValueError
+        If any gift amounts are negative.
     """
     a = _clean_nonneg_amounts(amounts)
     total = a.sum()
@@ -70,6 +75,11 @@ def top_donor_share(amounts: Collection, top_fraction: float = 0.1) -> float:
     float
         Share in ``[0.0, 1.0]``. Returns ``0.0`` for an empty input or an
         all-zero total.
+
+    Raises
+    ------
+    ValueError
+        If ``top_fraction`` is not in ``(0.0, 1.0]``, or if any gift amounts are negative.
     """
     if not 0.0 < top_fraction <= 1.0:
         raise ValueError("top_fraction must be in (0.0, 1.0].")

--- a/philanthropy/metrics/_fairness.py
+++ b/philanthropy/metrics/_fairness.py
@@ -40,6 +40,11 @@ def selection_rate_by_group(
     -------
     dict
         Mapping of group value -> selection rate in ``[0.0, 1.0]``.
+
+    Raises
+    ------
+    ValueError
+        If inputs have mismatched lengths, are empty, or contain missing values.
     """
     y_pred = np.asarray(y_pred)
     groups = np.asarray(sensitive_features)
@@ -91,6 +96,11 @@ def disparate_impact_ratio(
     float
         Ratio in ``[0.0, 1.0]``. Returns ``1.0`` when only one group is present
         or when no sample in any group is selected (no disparity to measure).
+
+    Raises
+    ------
+    ValueError
+        If inputs have mismatched lengths, are empty, or contain missing values.
     """
     rates = selection_rate_by_group(y_pred, sensitive_features, pos_label=pos_label)
     values = np.array(list(rates.values()), dtype=float)

--- a/philanthropy/metrics/_financial.py
+++ b/philanthropy/metrics/_financial.py
@@ -39,6 +39,11 @@ def donor_lifetime_value(
     -------
     float
         The calculated Net Present Value of the expected donor lifetime value.
+
+    Raises
+    ------
+    ValueError
+        If ``retention_rate``, ``lifespan_years``, or ``discount_rate`` is negative.
     """
     if retention_rate is not None:
         if retention_rate >= 1.0:


### PR DESCRIPTION
Resolves #61

**What changed:** Added explicit `Raises` sections to the docstrings of five metrics functions (`donor_lifetime_value`, `gift_concentration_gini`, `top_donor_share`, `selection_rate_by_group`, `disparate_impact_ratio`).
**Why:** To document the exact conditions under which these functions raise `ValueError`s, ensuring that the documented contract matches the explicit runtime validations.