### PR TITLE
docs: JOSS paper, PR body policy, ignore local todo file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ site/
 
 # Local working notes (not published)
 plan.md
+.outreach-todo.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ GitHub offers the button on your fork right after the push. Fill in the
 [CONTRIBUTORS.md](CONTRIBUTORS.md) in the same PR — one line, name or handle and
 what you did.
 
+A body of just `Resolves #N` is not enough — say what changed and why even
+when an issue is linked; reviewers read the PR body first, not the issue.
+
 CI runs on pull requests from forks. If a job fails, push another commit to the
 same branch — the PR updates itself.
 

--- a/paper.bib
+++ b/paper.bib
@@ -1,0 +1,37 @@
+@article{scikit-learn,
+  title   = {Scikit-learn: Machine Learning in {P}ython},
+  author  = {Pedregosa, Fabian and Varoquaux, Ga{\"e}l and Gramfort, Alexandre and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron and Dubourg, Vincent and Vanderplas, Jake and Passos, Alexandre and Cournapeau, David and Brucher, Matthieu and Perrot, Matthieu and Duchesnay, {\'E}douard},
+  journal = {Journal of Machine Learning Research},
+  volume  = {12},
+  pages   = {2825--2830},
+  year    = {2011}
+}
+
+@article{pandas,
+  title   = {Data Structures for Statistical Computing in {P}ython},
+  author  = {McKinney, Wes},
+  journal = {Proceedings of the 9th Python in Science Conference},
+  pages   = {56--61},
+  year    = {2010},
+  doi     = {10.25080/Majora-92bf1922-00a}
+}
+
+@article{numpy,
+  title   = {Array Programming with {N}um{P}y},
+  author  = {Harris, Charles R. and Millman, K. Jarrod and van der Walt, St{\'e}fan J. and Gommers, Ralf and Virtanen, Pauli and Cournapeau, David and Wieser, Eric and Taylor, Julian and Berg, Sebastian and Smith, Nathaniel J. and Kern, Robert and Picus, Matti and Hoyer, Stephan and van Kerkwijk, Marten H. and Brett, Matthew and Haldane, Allan and del R{\'i}o, Jaime Fern{\'a}ndez and Wiebe, Mark and Peterson, Pearu and G{\'e}rard-Marchant, Pierre and Sheppard, Kevin and Reddy, Tyler and Weckesser, Warren and Abbasi, Hameer and Gohlke, Christoph and Oliphant, Travis E.},
+  journal = {Nature},
+  volume  = {585},
+  pages   = {357--362},
+  year    = {2020},
+  doi     = {10.1038/s41586-020-2649-2}
+}
+
+@inproceedings{lalakiya2025,
+  title     = {{AI} for Advancement: Predictive Donor Analytics and Fundraising Intelligence at Scale},
+  author    = {Lalakiya, Shivam Ashokbhai},
+  booktitle = {2025 IEEE 11th International Conference on Computing, Engineering and Design (ICCED)},
+  pages     = {1--5},
+  year      = {2025},
+  publisher = {IEEE},
+  doi       = {10.1109/ICCED68324.2025.11325064}
+}

--- a/paper.md
+++ b/paper.md
@@ -1,0 +1,83 @@
+---
+title: 'PhilanthroPy: A scikit-learn-native toolkit for leakage-safe donor analytics in nonprofit and academic medical center fundraising'
+tags:
+  - Python
+  - scikit-learn
+  - philanthropy
+  - nonprofit
+  - fundraising
+  - predictive analytics
+  - healthcare
+authors:
+  - name: Shivam Ashokbhai Lalakiya
+    orcid: "0009-0000-5110-6540"
+    affiliation: 1
+affiliations:
+  - name: Independent Researcher
+    index: 1
+date: 11 August 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+PhilanthroPy is a scikit-learn-native Python library for predictive fundraising
+analytics at nonprofits and academic medical center (AMC) foundations. It
+covers the full predictive workflow used by advancement and development
+offices — CRM cleaning, wealth-screening imputation, RFM segmentation,
+donor-propensity and major-gift scoring, lapse prediction, planned-giving
+intent, share-of-wallet estimation, and hybrid revenue forecasting — as a set
+of `fit`/`transform`/`predict` estimators and transformers that compose
+directly inside `sklearn.pipeline.Pipeline` and pass
+`sklearn.utils.estimator_checks.check_estimator`. A second, AMC-specific
+surface (`EncounterTransformer`, `GratefulPatientFeaturizer`,
+`DischargeToSolicitationWindowTransformer`) featurizes clinical-encounter data
+for grateful-patient programs, where PHI-adjacent inputs raise the compliance
+bar relative to general nonprofit use.
+
+Every fitted statistic in the library — imputation fill values, wealth
+percentile lookups, fiscal-year boundaries — is computed from training data
+inside `fit` and frozen before `transform` or `predict` is ever called, so a
+pipeline built on PhilanthroPy cannot leak test-period or future information
+into a score without the user deliberately refitting on it. This contract is
+enforced by a dedicated regression test suite and holds a required coverage
+floor (currently 92% overall, 93% across the risk-tier subtree of
+preprocessing, models, and ingest) as a condition of every merge.
+
+# Statement of need
+
+Nonprofit and university advancement teams, and AMC development offices,
+routinely build donor-scoring models, but the tooling available to them sits
+at two extremes: proprietary, closed-source scoring add-ons bundled with CRM
+platforms (e.g. Salesforce NPSP, Blackbaud Raiser's Edge), which are not
+inspectable, not extensible, and not portable across systems; or ad hoc,
+one-off scripts written independently at each institution, which are rarely
+tested for the temporal-leakage failure mode endemic to donor data — fitting
+imputers, scalers, or feature encoders on a full historical dataset before
+splitting it into train and test windows, so a model's reported performance
+silently includes information from the future relative to the point a
+real solicitation decision would be made.
+
+PhilanthroPy addresses this gap by being simultaneously (1) fully
+`scikit-learn`-compatible, so it drops into existing cross-validation, grid
+search, and pipeline tooling that practitioners and researchers already use;
+(2) leakage-safe by construction and by test, rather than by convention; and
+(3) domain-specific, encoding fundraising and (for AMCs) grateful-patient
+program knowledge — such as discharge-to-solicitation windows and matching-gift
+detection — directly into named, documented transformers instead of leaving
+that domain logic to be re-derived ad hoc at every institution. The
+compliance posture is scoped explicitly: PhilanthroPy documents where its PII
+handling is a name-based heuristic rather than a formal HIPAA
+de-identification, so AMC adopters can make an informed risk decision instead
+of assuming a guarantee the library does not make.
+
+The library's design and target use case are grounded in the author's
+published work on predictive donor analytics and fundraising intelligence at
+scale [@lalakiya2025], and it is built on the standard scientific Python stack
+[@scikit-learn; @numpy; @pandas].
+
+# Acknowledgements
+
+We thank the PhilanthroPy contributors credited in `CONTRIBUTORS.md`.
+
+# References


### PR DESCRIPTION
## Summary
- Add JOSS paper draft (paper.md, paper.bib) for submission.
- Require PR bodies to explain what/why, not just "Resolves #N" (CONTRIBUTING.md).
- Ignore a local-only outreach todo file that shouldn't be tracked.

## Why
Batches three small doc-only commits that were sitting on local main, blocked from a direct push by branch protection (12 required status checks).