### PR TITLE
docs: require every change to go through a PR, never merge to main directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,11 @@ separate, higher floor over the risk-tier subtree. CI runs both
 (`.github/workflows/ci.yml`). Do not hardcode either number anywhere else —
 that drift is what issues #21 and #22 exist to fix.
 
+## Branching — no direct commits to main
+Every change — including maintainer- and agent-authored ones — goes on a feature
+branch and through a pull request. Never commit or push straight to `main`, and
+never merge your own PR; open it and leave the merge to review.
+
 ## Every PR must also
 - Add an entry under `## [Unreleased]` in CHANGELOG.md.
 - Add yourself to CONTRIBUTORS.md (same PR).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `AGENTS.md`: every change, including maintainer- and agent-authored ones, must
+  go on a branch and through a PR — no direct commits to `main`, no self-merges.
 - `tests/test_no_network.py` enforces in CI what the docs now promise: the package
   makes **no network calls**. Every socket entry point is monkeypatched to raise,
   then a full train/score cycle, an imputation pass and a CiviCRM ingest all run.


### PR DESCRIPTION
## Summary
- Codifies existing practice as an explicit `AGENTS.md` rule: every change — including maintainer- and agent-authored ones — goes on a branch and through a PR, never a direct commit/merge to `main`, and PR authors don't self-merge.
- No code behavior changes.

## Why
Nothing in the repo previously said this out loud for the maintainer/agent path (`CONTRIBUTING.md` covers external forks). Making it explicit keeps future agent sessions on the same rail.

## Test plan
- [x] `make ci` — 1687 passed, 2 skipped (full suite ran via pre-push hook)