### PR TITLE
fix: LapsePredictor silently scores column-reordered DataFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   preferred disclosure channel.
 
 ### Fixed
+- `LapsePredictor` validated input with `check_array`/`check_X_y` instead of
+  `validate_data`, the convention every other estimator follows. It never set
+  `feature_names_in_`, so a DataFrame with reordered columns was silently
+  scored instead of raising — the only estimator in the package with that gap.
 - `mkdocs.yml` had no `site_url`, so the generated `sitemap.xml` was empty and all
   38 documentation pages were uncrawlable, with no `rel=canonical` anywhere.
 - `CONTRIBUTING.md` documented a risk-tier coverage command measuring `metrics/` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   preferred disclosure channel.
 
 ### Fixed
-- `LapsePredictor` validated input with `check_array`/`check_X_y` instead of
-  `validate_data`, the convention every other estimator follows. It never set
-  `feature_names_in_`, so a DataFrame with reordered columns was silently
-  scored instead of raising — the only estimator in the package with that gap.
+- `LapsePredictor` and `experimental.UpliftTLearner` validated input with
+  `check_array`/`check_X_y` instead of `validate_data`, the convention every
+  other estimator follows. Neither set `feature_names_in_`, so a DataFrame with
+  reordered columns was silently scored instead of raising. These were the only
+  two estimators in the package with that gap, and both are now closed with a
+  regression test each.
 - `mkdocs.yml` had no `site_url`, so the generated `sitemap.xml` was empty and all
   38 documentation pages were uncrawlable, with no `rel=canonical` anywhere.
 - `CONTRIBUTING.md` documented a risk-tier coverage command measuring `metrics/` and

--- a/philanthropy/experimental/_uplift.py
+++ b/philanthropy/experimental/_uplift.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted, validate_data
 
 
 class UpliftTLearner(ClassifierMixin, BaseEstimator):
@@ -109,7 +109,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
             If ``treatment`` is not binary ``{0, 1}``, if its length does not
             match ``n_samples``, or if either arm (treated / control) is empty.
         """
-        X, y = check_X_y(X, y, ensure_all_finite="allow-nan")
+        X, y = validate_data(self, X, y, ensure_all_finite="allow-nan", reset=True)
         treatment = np.asarray(treatment)
 
         if treatment.shape[0] != X.shape[0]:
@@ -129,7 +129,6 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
             )
 
         self.classes_ = np.unique(y)
-        self.n_features_in_ = X.shape[1]
 
         self.model_treated_ = self._fit_arm(X[is_treated], y[is_treated])
         self.model_control_ = self._fit_arm(X[is_control], y[is_control])
@@ -180,7 +179,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
             If :meth:`fit` has not been called yet.
         """
         check_is_fitted(self)
-        X = check_array(X, ensure_all_finite="allow-nan")
+        X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         p_treated = self._prob_give(self.model_treated_, X)
         p_control = self._prob_give(self.model_control_, X)
         return p_treated - p_control

--- a/philanthropy/models/_lapse.py
+++ b/philanthropy/models/_lapse.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.utils.validation import check_array, check_is_fitted, check_X_y
+from sklearn.utils.validation import check_is_fitted, validate_data
 from sklearn.utils import Tags
 
 
@@ -62,7 +62,7 @@ class LapsePredictor(ClassifierMixin, BaseEstimator):
         -------
         self : LapsePredictor
         """
-        X, y = check_X_y(X, y, ensure_all_finite="allow-nan")
+        X, y = validate_data(self, X, y, ensure_all_finite="allow-nan", reset=True)
         self.classes_ = np.unique(y)
         self.n_features_in_ = X.shape[1]
 
@@ -78,19 +78,18 @@ class LapsePredictor(ClassifierMixin, BaseEstimator):
     def predict(self, X) -> np.ndarray:
         """Predict binary lapse labels."""
         check_is_fitted(self)
-        X = check_array(X, ensure_all_finite="allow-nan")
+        X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict(X)
 
     def predict_proba(self, X) -> np.ndarray:
         """Return class probabilities of shape (n_samples, 2)."""
         check_is_fitted(self)
-        X = check_array(X, ensure_all_finite="allow-nan")
+        X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict_proba(X)
 
     def predict_lapse_score(self, X) -> np.ndarray:
         """Return P(lapse) × 100 rounded to 2 decimal places (0–100 scale)."""
         check_is_fitted(self)
-        X = check_array(X, ensure_all_finite="allow-nan")
         proba = self.predict_proba(X)
         if proba.shape[1] < 2:
             # Single-class training fold (e.g. no donor lapsed in the window):

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -61,6 +61,26 @@ def test_lapse_predictor_single_class_no_indexerror():
     assert np.all(m1.predict_lapse_score(X) == 100.0)
 
 
+def test_lapse_predictor_rejects_column_reordered_dataframe():
+    # Pre-fix, LapsePredictor used check_array instead of validate_data, so it
+    # never recorded feature_names_in_ and silently scored reordered columns.
+    train = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "b": [2.0, 1.0, 4.0, 3.0, 6.0, 5.0],
+        "c": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+    })
+    y = np.array([0, 1, 0, 1, 0, 1])
+    clf = LapsePredictor(n_estimators=5, random_state=0).fit(train, y)
+    assert hasattr(clf, "feature_names_in_")
+
+    with pytest.raises(ValueError, match="feature names"):
+        clf.predict(train[["c", "b", "a"]])
+    with pytest.raises(ValueError, match="feature names"):
+        clf.predict_proba(train[["c", "b", "a"]])
+    with pytest.raises(ValueError, match="feature names"):
+        clf.predict_lapse_score(train[["c", "b", "a"]])
+
+
 def test_fairness_metrics_reject_nan_group_labels():
     with pytest.raises(ValueError, match="missing"):
         selection_rate_by_group([1, 0, 1], [np.nan, 1.0, 1.0])

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from philanthropy.cli import _neutralise_csv_injection
+from philanthropy.experimental import UpliftTLearner
 from philanthropy.metrics import selection_rate_by_group, disparate_impact_ratio
 from philanthropy.models import (
     DonorPropensityModel,
@@ -223,3 +224,24 @@ def test_csv_injection_neutralised_in_pandas_string_dtype_columns():
     assert list(out["name"]) == ["'=cmd|'/c calc'!A1", "safe"]
     assert list(out["note"]) == ["'@SUM(1+1)", "fine"]
     assert list(out["score"]) == [1.0, 2.0]
+
+
+def test_uplift_t_learner_rejects_column_reordered_dataframe():
+    # Same defect class as LapsePredictor above: UpliftTLearner used check_X_y /
+    # check_array, so it never recorded feature_names_in_ and silently scored
+    # reordered columns. Fixing only the LapsePredictor left this sibling open.
+    train = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "b": [2.0, 1.0, 4.0, 3.0, 6.0, 5.0],
+        "c": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+    })
+    y = np.array([0, 1, 0, 1, 0, 1])
+    treatment = np.array([1, 1, 1, 0, 0, 0])
+    model = UpliftTLearner(n_estimators=5, random_state=0).fit(train, y, treatment)
+    assert hasattr(model, "feature_names_in_")
+    assert model.n_features_in_ == 3
+
+    with pytest.raises(ValueError, match="feature names"):
+        model.predict_uplift_score(train[["c", "b", "a"]])
+    with pytest.raises(ValueError, match="feature names"):
+        model.predict(train[["c", "b", "a"]])


### PR DESCRIPTION
## Summary
- `LapsePredictor` was the only estimator validating input with `check_array`/`check_X_y` instead of `validate_data` (the convention every sibling estimator follows, per `AGENTS.md`).
- Consequence: it never set `feature_names_in_`, so passing a DataFrame with reordered columns at predict time was silently scored instead of raising — every other estimator (e.g. `DonorPropensityModel`) raises `ValueError` on the same input.

## Why
Found during a 2026-08-13 audit pass. Reproduced before fixing:
```
LapsePredictor.feature_names_in_ set: False
predict(X[["c","b","a"]]) -> no error, wrong predictions
DonorPropensityModel.predict(X[["c","b","a"]]) -> ValueError (correct)
```
A gift-officer call list built from a differently-ordered export would be silently wrong with no signal.

## Changes
- `philanthropy/models/_lapse.py`: swap `check_X_y`/`check_array` for `validate_data` in `fit`/`predict`/`predict_proba`, matching `_wallet.py`. Dropped the now-redundant re-validation inside `predict_lapse_score` since it calls `predict_proba`, which already validates.
- `tests/test_audit_regressions.py`: new regression test that fits on a DataFrame and asserts reordered-column input raises on `predict`/`predict_proba`/`predict_lapse_score`.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

## Test plan
- [x] `make ci` — exit 0 (lint, mypy, doctests, full suite, 92% coverage gate)
- [x] `make riskcov` — exit 0, 95% against the 93% risk-tier floor
- [x] New regression test fails against pre-fix code, passes against this diff