### PR TITLE
fix: CRMCleaner NaNs currency-formatted gift amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   preferred disclosure channel.
 
 ### Fixed
+- `CRMCleaner` NaN'd every value in a currency-formatted amount column, e.g.
+  `"$1,000.00"` — the default export format for Raiser's Edge NXT and
+  Salesforce NPSP — because `pd.to_numeric` treats the whole string as
+  unparseable. It now strips currency symbols, thousands separators and
+  parenthesised negatives before parsing, and raises rather than returning an
+  all-NaN column when a column truly has nothing parseable in it.
 - `mkdocs.yml` had no `site_url`, so the generated `sitemap.xml` was empty and all
   38 documentation pages were uncrawlable, with no `rel=canonical` anywhere.
 - `CONTRIBUTING.md` documented a risk-tier coverage command measuring `metrics/` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Salesforce NPSP — because `pd.to_numeric` treats the whole string as
   unparseable. It now strips currency symbols, thousands separators and
   parenthesised negatives before parsing, and raises rather than returning an
-  all-NaN column when a column truly has nothing parseable in it.
+  all-NaN column when a column truly has nothing parseable in it. The
+  string/numeric branch checks `pd.api.types.is_numeric_dtype` rather than
+  `dtype == object`, so it also parses correctly under pandas 3.0's non-object
+  default string dtype, not just the legacy `object` dtype.
 - `mkdocs.yml` had no `site_url`, so the generated `sitemap.xml` was empty and all
   38 documentation pages were uncrawlable, with no `rel=canonical` anywhere.
 - `CONTRIBUTING.md` documented a risk-tier coverage command measuring `metrics/` and

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -47,6 +47,32 @@ def _get_pandas_output(estimator: Any) -> bool:
     return False
 
 
+def _coerce_currency_to_float(col: pd.Series) -> pd.Series:
+    """Parse a gift-amount column to float64, tolerating currency formatting.
+
+    Raiser's Edge NXT and Salesforce NPSP both export amounts as
+    ``"$1,000.00"`` by default; a bare ``pd.to_numeric`` treats every such
+    value as unparseable and NaNs the whole column. This strips currency
+    symbols, thousands separators and parenthesised negatives
+    (``"($500.00)"`` -> ``-500.0``) before parsing.
+    """
+    if col.dtype != object:
+        return pd.to_numeric(col, errors="coerce").astype("float64")
+
+    had_value = col.notna()
+    cleaned = col.astype(str).str.strip()
+    cleaned = cleaned.str.replace(r"^\((.*)\)$", r"-\1", regex=True)
+    cleaned = cleaned.str.replace(r"[^0-9eE.\-]", "", regex=True)
+    parsed = pd.to_numeric(cleaned, errors="coerce").where(had_value)
+
+    if had_value.any() and parsed.isna().all():
+        raise ValueError(
+            f"CRMCleaner: could not parse any value in amount column "
+            f"{col.name!r} as a number."
+        )
+    return parsed.astype("float64")
+
+
 class CRMCleaner(TransformerMixin, BaseEstimator):
     """Standardise raw CRM exports.
 
@@ -62,7 +88,10 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         during :meth:`transform`.
     amount_col : str, default="gift_amount"
         Column containing raw gift amounts.  Forced to ``float64`` during
-        :meth:`transform`; non-numeric values become ``NaN``.
+        :meth:`transform`; currency symbols, thousands separators and
+        parenthesised negatives (``"$1,000.00"``, ``"($500.00)"``) are
+        stripped before parsing.  Values that still don't parse become
+        ``NaN``; a column where *nothing* parses raises instead.
     fiscal_year_start : int, default=7
         Month (1–12) that begins the organisation's fiscal year.  Validated in
         :meth:`fit` but **not** used by :meth:`transform`, which only coerces
@@ -163,7 +192,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         if self.date_col in X_df.columns:
             X_df[self.date_col] = pd.to_datetime(X_df[self.date_col], errors="coerce")
         if self.amount_col in X_df.columns:
-            X_df[self.amount_col] = pd.to_numeric(X_df[self.amount_col], errors="coerce")
+            X_df[self.amount_col] = _coerce_currency_to_float(X_df[self.amount_col])
 
         if _get_pandas_output(self):
             return X_df

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -56,7 +56,7 @@ def _coerce_currency_to_float(col: pd.Series) -> pd.Series:
     symbols, thousands separators and parenthesised negatives
     (``"($500.00)"`` -> ``-500.0``) before parsing.
     """
-    if col.dtype != object:
+    if pd.api.types.is_numeric_dtype(col):
         return pd.to_numeric(col, errors="coerce").astype("float64")
 
     had_value = col.notna()

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -73,8 +73,28 @@ class TestCRMCleaner:
         )
         cleaner = CRMCleaner().set_output(transform="pandas")
         out = cleaner.fit_transform(df)
-        # Non-parseable → NaN; dtype should be float64
-        assert out["gift_amount"].dtype == np.float64 or out["gift_amount"].isna().all()
+        assert out["gift_amount"].dtype == np.float64
+        assert out["gift_amount"].iloc[0] == 5000.0
+
+    def test_amount_col_strips_currency_formatting(self):
+        # Raiser's Edge NXT / Salesforce NPSP export amounts exactly like this
+        # by default. A bare pd.to_numeric NaNs the whole column.
+        df = pd.DataFrame({
+            "gift_date": ["2024-01-01", "2024-02-01", "2024-03-01"],
+            "gift_amount": ["$1,000.00", "$250.50", "($75.00)"],
+        })
+        cleaner = CRMCleaner().set_output(transform="pandas")
+        out = cleaner.fit_transform(df)
+        assert list(out["gift_amount"]) == [1000.0, 250.5, -75.0]
+
+    def test_amount_col_unparseable_column_raises(self):
+        df = pd.DataFrame({
+            "gift_date": ["2024-01-01", "2024-02-01"],
+            "gift_amount": ["not a number", "also not a number"],
+        })
+        cleaner = CRMCleaner()
+        with pytest.raises(ValueError, match="could not parse"):
+            cleaner.fit_transform(df)
 
     def test_date_col_coerced_to_datetime(self):
         df = pd.DataFrame({"gift_date": ["2023-07-01"], "gift_amount": [100.0]})


### PR DESCRIPTION
## Summary
- `CRMCleaner.transform` fed the amount column straight to `pd.to_numeric`, which treats `"$1,000.00"` as entirely unparseable and NaNs the whole column.
- That is the *default* export format for Raiser's Edge NXT and Salesforce NPSP — the two CRMs the docs name as the target audience — so this silently zeroed out gift amounts for the common case, not an edge case.

## Why
Found during a 2026-08-13 audit. Reproduced before fixing:
```python
CRMCleaner().fit_transform(pd.DataFrame({
    "gift_date": ["2024-01-01", "2024-02-01"],
    "gift_amount": ["$1,000.00", "$250.00"],
}))["gift_amount"].tolist()
# -> [nan, nan]
```
The existing test (`test_amount_col_coerced_to_float`) had actually been written loose enough to accept this (`dtype == float64 OR isna().all()`) — a tell that the bug was known-shaped even if not flagged.

## Changes
- `philanthropy/preprocessing/_transformers.py`: new `_coerce_currency_to_float` helper — strips `$`, thousands separators, and converts parenthesised negatives (`"($500.00)"` → `-500.0`) before `pd.to_numeric`. Raises `ValueError` if a column has real values but none of them parse, instead of silently returning all-NaN. Non-object (already-numeric) columns are cast to `float64` as before, just made explicit.
- `tests/test_preprocessing.py`: tightened `test_amount_col_coerced_to_float` to assert the actual parsed value instead of accepting the all-NaN escape hatch; added `test_amount_col_strips_currency_formatting` and `test_amount_col_unparseable_column_raises`.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

## Test plan
- [x] `rtk proxy make ci` — 1690 passed, 2 skipped, 95.45% coverage (gate 92%)
- [x] `rtk proxy make riskcov` — 95% (floor 93%)
- [x] Targeted: `pytest tests/test_preprocessing.py tests/test_leakage.py tests/test_sklearn_compliance.py tests/test_public_api_contract.py tests/test_cli.py` — 1109 passed, 2 skipped