### PR TITLE
Add test coverage for constituent_events_to_features guard branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- Test coverage for `constituent_events_to_features`: the all-unparseable-timestamps empty-frame path and the `distinct_source_systems` default-to-zero path when `sourceSystem` is absent from the input. (#51)
 - `AGENTS.md`: every change, including maintainer- and agent-authored ones, must
   go on a branch and through a PR — no direct commits to `main`, no self-merges.
 - `tests/test_no_network.py` enforces in CI what the docs now promise: the package

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,7 +24,10 @@ contribution. Code, docs, tests, and review all count.
   [#42](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/42),
   [#43](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/43),
   [#44](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/44)).
-
+- [@AsavariCharati](https://github.com/AsavariCharati) — added test coverage for
+  two untested guards in `constituent_events_to_features`: the all-unparseable-
+  timestamps empty-frame path and the `distinct_source_systems` default when
+  `sourceSystem` is absent.
 ## Getting listed
 
 Add yourself here in the same pull request as your change — one line, your name

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -103,6 +103,15 @@ def test_distinct_source_systems():
     feats = constituent_events_to_features(events)
     assert feats.loc["a@x.edu", "distinct_source_systems"] == 2
 
+def test_distinct_source_systems_defaults_to_zero_when_column_absent():
+    events = [
+        {"constituentEmail": "a@x.edu",
+         "createdAt": "2025-01-01T00:00:00Z", "amount": 10.0},  # no sourceSystem
+        {"constituentEmail": "a@x.edu",
+         "createdAt": "2025-02-01T00:00:00Z", "amount": 20.0},  # no sourceSystem
+    ]
+    feats = constituent_events_to_features(events)
+    assert feats.loc["a@x.edu", "distinct_source_systems"] == 0
 
 # --------------------------------------------------------------------------- #
 # Identity resolution
@@ -201,6 +210,15 @@ def test_unparseable_timestamp_row_dropped():
     feats = constituent_events_to_features(events)
     assert feats.loc["a@x.edu", "total_gift_amount"] == 100.0
 
+def test_all_unparseable_timestamps_returns_empty_frame():
+    events = [
+        _event("a@x.edu", "DONATION", "not-a-date", amount=999),
+        _event("b@x.edu", "EMAIL_CLICK", "also-not-a-date"),
+    ]
+    feats = constituent_events_to_features(events)
+    assert feats.empty
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+    assert feats.index.name == "constituent_id"
 
 def test_reference_date_shifts_recency():
     events = [_event("a@x.edu", "DONATION", "2025-01-01T00:00:00Z", amount=100)]


### PR DESCRIPTION
Resolves #51

Adds the two missing tests for `constituent_events_to_features`:

- `test_all_unparseable_timestamps_returns_empty_frame` — every event has an unparseable `createdAt`, so all rows are dropped by the `_ts.notna()` filter, leaving `df` empty and hitting the second `_empty_feature_frame()` return (distinct from the empty-input path, which returns before any filtering runs). Same shape assertions as `test_empty_input_returns_typed_empty_frame`.
- `test_distinct_source_systems_defaults_to_zero_when_column_absent` — builds events as plain dicts (not the `_event()` helper, which always sets `sourceSystem`) with the key fully absent, asserting `distinct_source_systems == 0`.

Verified locally:
- `python -m coverage run -m pytest tests/test_ingest.py -q` → 41 passed
- `python -m coverage report --include='philanthropy/ingest/_constituent_events.py' --fail-under=100` → 100% coverage, no missing lines
- `flake8`, `mypy`, and `--doctest-modules` all clean

Added a CHANGELOG entry under [Unreleased] and myself to CONTRIBUTORS.md.