### PR TITLE
feat(metrics): conformal p-value for donor scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `philanthropy.metrics.conformal_pvalue` — the non-smoothed split-conformal
+  p-value of a donor score against a held-out calibration set,
+  `(1 + |{i : s_i >= s}|) / (n + 1)`. A calibrated probability threshold fixes no
+  error rate; thresholding this p-value at `alpha` bounds the false-positive rate
+  at `alpha` in finite samples with no distributional assumption. Both the `1 +`
+  and the `+ 1` are load-bearing and tested: the result is never 0 and never
+  above 1, and leave-one-out over exchangeable scores lands exactly on the
+  uniform lattice.
 - Test coverage for `constituent_events_to_features`: the all-unparseable-timestamps empty-frame path and the `distinct_source_systems` default-to-zero path when `sourceSystem` is absent from the input. (#51)
 - `AGENTS.md`: every change, including maintainer- and agent-authored ones, must
   go on a branch and through a PR — no direct commits to `main`, no self-merges.

--- a/paper.bib
+++ b/paper.bib
@@ -35,3 +35,12 @@
   publisher = {IEEE},
   doi       = {10.1109/ICCED68324.2025.11325064}
 }
+
+@article{vovk2005conformal,
+  title     = {Algorithmic Learning in a Random World},
+  author    = {Vovk, Vladimir and Gammerman, Alexander and Shafer, Glenn},
+  publisher = {Springer},
+  year      = {2005},
+  journal   = {Springer},
+  doi       = {10.1007/b106715}
+}

--- a/paper.md
+++ b/paper.md
@@ -71,6 +71,15 @@ handling is a name-based heuristic rather than a formal HIPAA
 de-identification, so AMC adopters can make an informed risk decision instead
 of assuming a guarantee the library does not make.
 
+A donor score is almost always consumed as a threshold crossing: a
+solicitation is triggered when a score clears a cut point. `philanthropy.metrics`
+therefore also exposes `conformal_pvalue`, the non-smoothed split-conformal
+p-value of a scored donor against a held-out calibration set
+[@vovk2005conformal], in the `(1 + |{i : s_i >= s}|) / (n + 1)` form that
+retains the calibration point in the index set. The result is a
+distribution-free, finite-sample valid cut point, rather than a hand-picked
+probability threshold whose false-positive rate is unknown.
+
 The library's design and target use case are grounded in the author's
 published work on predictive donor analytics and fundraising intelligence at
 scale [@lalakiya2025], and it is built on the standard scientific Python stack

--- a/philanthropy/metrics/__init__.py
+++ b/philanthropy/metrics/__init__.py
@@ -13,6 +13,7 @@ from ._scoring import (
 from ._financial import donor_lifetime_value
 from ._fairness import disparate_impact_ratio, selection_rate_by_group
 from ._concentration import gift_concentration_gini, top_donor_share
+from ._conformal import conformal_pvalue
 
 __all__ = [
     "donor_retention_rate",
@@ -24,4 +25,5 @@ __all__ = [
     "selection_rate_by_group",
     "gift_concentration_gini",
     "top_donor_share",
+    "conformal_pvalue",
 ]

--- a/philanthropy/metrics/_conformal.py
+++ b/philanthropy/metrics/_conformal.py
@@ -1,0 +1,89 @@
+"""
+philanthropy.metrics._conformal
+================================
+Distribution-free p-values for donor scores.
+
+A donor score is consumed as a threshold crossing: a solicitation fires when
+the score clears a cut point. Picking that cut point from a calibrated
+probability ("contact everyone above 0.8") fixes no error rate at all. The
+split-conformal p-value does: rank a scored donor against a held-out
+calibration set and the result is uniform on the lattice under exchangeability,
+so thresholding it at ``alpha`` bounds the false-positive rate at ``alpha`` in
+finite samples, with no distributional assumption.
+
+Only the non-smoothed form is implemented, eq. (3) of Bates et al. (2023):
+
+    p = (1 + |{i : s_i >= s}|) / (n + 1)
+
+The ``1 +`` in the numerator and the ``+ 1`` in the denominator are the test
+point itself. Both are load-bearing. Dropping either one produces a statistic
+that is not a valid p-value, and dropping only the numerator's can return a
+value above 1.
+"""
+
+from __future__ import annotations
+
+from typing import Collection
+
+import numpy as np
+
+
+def conformal_pvalue(calibration_scores: Collection, scores: Collection) -> np.ndarray:
+    """Split-conformal p-value of each score against a calibration set.
+
+    Small p-values mean the score is high relative to the calibration donors,
+    so ``conformal_pvalue(...) <= alpha`` selects the donors whose scores are
+    extreme at level ``alpha``. The calibration scores must come from donors
+    held out of training, exchangeable with the ones being scored; reusing
+    training rows breaks the guarantee exactly the way refitting a transformer
+    on test data does.
+
+    Parameters
+    ----------
+    calibration_scores : array-like of shape (n_calibration,)
+        Scores of held-out donors, higher meaning more likely to give. Must be
+        non-empty and finite; ``NaN`` and infinities raise rather than being
+        dropped, because the denominator ``n + 1`` counts them.
+    scores : array-like of shape (n_samples,)
+        Scores to test. May be a scalar-like sequence of any length, including
+        empty. ``NaN`` entries yield ``NaN`` p-values.
+
+    Returns
+    -------
+    ndarray of shape (n_samples,)
+        P-values in ``[1 / (n_calibration + 1), 1.0]``. Never 0, never above 1.
+
+    Raises
+    ------
+    ValueError
+        If ``calibration_scores`` is empty, not one-dimensional, or contains
+        non-finite values.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from philanthropy.metrics import conformal_pvalue
+    >>> calibration = np.arange(9, dtype=float)          # 0 .. 8, n = 9
+    >>> conformal_pvalue(calibration, [8.5, 4.0, -1.0])
+    array([0.1, 0.6, 1. ])
+
+    A score above every calibration point still gets ``1 / (n + 1)``, not 0:
+
+    >>> float(conformal_pvalue(calibration, [1e6])[0])
+    0.1
+    """
+    cal = np.asarray(calibration_scores, dtype=float)
+    if cal.ndim != 1:
+        raise ValueError("calibration_scores must be one-dimensional.")
+    if cal.size == 0:
+        raise ValueError("calibration_scores must be non-empty.")
+    if not np.all(np.isfinite(cal)):
+        raise ValueError("calibration_scores must be finite (no NaN or inf).")
+
+    s = np.asarray(scores, dtype=float)
+    n = cal.size
+    cal_sorted = np.sort(cal)
+    # |{i : cal_i >= s}| — 'left' so calibration points equal to s are counted.
+    n_ge = n - np.searchsorted(cal_sorted, s, side="left")
+    p = (1.0 + n_ge) / (n + 1.0)
+    return np.where(np.isnan(s), np.nan, p)

--- a/tests/test_conformal.py
+++ b/tests/test_conformal.py
@@ -1,0 +1,65 @@
+"""Tests for the split-conformal p-value of a donor score."""
+
+import numpy as np
+import pytest
+
+from philanthropy.metrics import conformal_pvalue
+
+
+def test_exact_lattice_values():
+    # n = 9 calibration scores 0..8. |{i : cal_i >= s}| is 0, 5 and 9.
+    cal = np.arange(9, dtype=float)
+    assert conformal_pvalue(cal, [8.5, 4.0, -1.0]) == pytest.approx([0.1, 0.6, 1.0])
+
+
+def test_ties_are_counted():
+    # A score equal to a calibration point counts that point as >= itself.
+    cal = np.array([1.0, 2.0, 3.0])
+    # {2.0, 3.0} are >= 2.0 → (1 + 2) / 4.
+    assert conformal_pvalue(cal, [2.0])[0] == pytest.approx(0.75)
+
+
+def test_never_zero_and_never_above_one():
+    # The bug the n+1 denominator and the 1+ numerator exist to prevent:
+    # a p-value of 0 for an unbeatable score, or one above 1 for a hopeless one.
+    cal = np.linspace(0.0, 1.0, 50)
+    p = conformal_pvalue(cal, [1e9, -1e9, 0.5])
+    assert p.min() == pytest.approx(1.0 / 51.0)
+    assert p.max() == pytest.approx(1.0)
+    assert np.all(p > 0.0)
+    assert np.all(p <= 1.0)
+
+
+def test_marginal_validity_is_exact_on_the_lattice():
+    # Leave-one-out over m+1 exchangeable, distinct scores: each rotation must
+    # produce a distinct lattice point, so the p-values are exactly uniform on
+    # {1/(m+1), ..., 1} and P(p <= alpha) <= alpha holds with no slack.
+    values = np.arange(20, dtype=float) * 1.7
+    p = np.array(
+        [
+            conformal_pvalue(np.delete(values, j), [values[j]])[0]
+            for j in range(values.size)
+        ]
+    )
+    assert sorted(p) == pytest.approx(sorted(np.arange(1, 21) / 20.0))
+    for alpha in (0.05, 0.1, 0.25, 0.5):
+        assert np.mean(p <= alpha) <= alpha + 1e-12
+
+
+def test_nan_scores_propagate():
+    p = conformal_pvalue([1.0, 2.0, 3.0], [2.0, np.nan])
+    assert p[0] == pytest.approx(0.75)
+    assert np.isnan(p[1])
+
+
+def test_empty_scores_returns_empty():
+    assert conformal_pvalue([1.0, 2.0], []).shape == (0,)
+
+
+@pytest.mark.parametrize(
+    "bad_calibration",
+    [[], [[1.0, 2.0], [3.0, 4.0]], [1.0, np.nan], [1.0, np.inf]],
+)
+def test_invalid_calibration_raises(bad_calibration):
+    with pytest.raises(ValueError):
+        conformal_pvalue(bad_calibration, [1.0])


### PR DESCRIPTION
A donor score is consumed as a threshold crossing: a solicitation fires when the score clears a cut point. Picking that cut point from a calibrated probability ("contact everyone above 0.8") fixes no error rate at all.

`philanthropy.metrics.conformal_pvalue` ranks a scored donor against a held-out calibration set and returns the non-smoothed split-conformal p-value:

    p = (1 + |{i : s_i >= s}|) / (n + 1)

Thresholding that at `alpha` bounds the false-positive rate at `alpha` in finite samples, with no distributional assumption. It gives the library a defensible cut point instead of a hand-picked probability whose false-positive rate is unknown.

## Why both constants matter

The leading `1 +` and the `+ 1` denominator are the test point itself. Drop either and the statistic stops being a valid p-value: it can return 0 for an unbeatable score, or a value above 1 for a hopeless one. Both are covered by tests rather than left as comments.

## Tests

`tests/test_conformal.py`, 7 tests:

- exact lattice values on a known calibration set
- ties counted (a score equal to a calibration point counts that point)
- never 0, never above 1, at both extremes
- exact marginal validity: leave-one-out over exchangeable scores lands on the uniform lattice and `P(p <= alpha) <= alpha` holds with no slack
- NaN scores propagate rather than being silently dropped
- empty `scores` returns an empty array
- invalid calibration (empty, 2-D, NaN, inf) raises `ValueError`

## Paper

Adds one paragraph to `paper.md` introducing the function, plus the `vovk2005conformal` reference. The rest of the JOSS paper prep is a separate PR so this one stays reviewable.

## Verification

    make ci        # exit 0, 1700 passed, 2 skipped
    make riskcov   # 95% against the 93% floor

Overall coverage 95.70% against the 92% floor; `philanthropy/metrics/_conformal.py` at 100%.

CHANGELOG updated under `## [Unreleased]`. No CONTRIBUTORS.md entry needed (maintainer already listed). No docs page needed: `docs/reference/metrics.md` is `::: philanthropy.metrics` autodoc and `tests/test_public_api_contract.py` covers `philanthropy.metrics` with a blanket stability-tier row.