### PR TITLE
chore: roll version metadata back to the release that exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   preferred disclosure channel.
 
 ### Fixed
+- Version metadata now names the release that actually exists. `pyproject.toml`
+  and `CITATION.cff` both declared `1.0.0`, which has no git tag, no PyPI
+  artifact and no Zenodo deposit; PyPI's newest is `0.6.0` and so is the newest
+  tag. `CITATION.cff` additionally dated that phantom 1.0.0 to `2026-08-01`,
+  which is 0.6.0's release date, and its DOI comment cited the v0.6.0
+  per-version DOI while the file claimed 1.0.0. Both now say `0.6.0`, and the
+  comment states the rule: `version` tracks the newest **published** release,
+  not `main`. `main` continues to carry unreleased `0.7.0` and `1.0.0` work, and
+  those CHANGELOG headings stay `- TBD` until a release is cut. This also
+  unblocks the JOSS archive step, which requires the submitted version to
+  correspond to a real tagged, archived release. `RELEASING.md`'s "cutting a
+  release `main` has already moved past" section assumed the tip carried the
+  newest staged version and walked through tagging an older commit; with the
+  tip back at the published version the normal branch-bump-date-tag path
+  applies, so that section documents that instead and keeps the older-commit
+  case as the caveat it is. Closes #88.
 - **`generate_synthetic_donor_data` ran the domain's causal arrow backwards.**
   It drew `is_major_donor` from a logistic model of `years_active` and
   `event_attendance_count`, then drew `total_gift_amount` *conditional on that

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,14 +11,17 @@ authors:
   - family-names: Lalakiya
     given-names: Shivam
     email: shivamlalakiya151299@gmail.com
-version: 1.0.0
+version: 0.6.0
 date-released: "2026-08-01"
 license: MIT
 repository-code: "https://github.com/PhilanthroPy-Project/PhilanthroPy"
 url: "https://PhilanthroPy-Project.github.io/PhilanthroPy/"
 # Zenodo concept DOI: always resolves to the latest deposited release. This is
-# deliberately NOT the per-version DOI (v0.6.0 is 10.5281/zenodo.21751097); the
-# concept DOI is the one to cite so the reference does not go stale.
+# deliberately NOT the per-version DOI, which for this release (0.6.0) is
+# 10.5281/zenodo.21751097. Cite the concept DOI so the reference does not go
+# stale. `version` above tracks the newest PUBLISHED release, not `main`:
+# main carries unreleased 0.7.0 and 1.0.0 work, and citing a version nobody
+# can install is worse than citing one release behind.
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21751096"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -70,23 +70,34 @@ Run in order. Steps 1–6 are the gate `publish.yml` enforces; 7–9 are manual.
 A shim added in `X.Y.0` may only be removed in `X.(Y+1).0` **after `X.Y.0` is
 published on PyPI**: one full published minor of overlap, not one commit.
 
-### Cutting a release `main` has already moved past
+### Cutting a release with several versions staged on `main`
 
 `main` can carry more than one unreleased version; 0.7.0 and 1.0.0 are both
 merged and both still `- TBD`. The gate compares the tag against the
-`pyproject.toml` **of the commit the tag points at**, so once a later version
-has bumped that file at the tip, the older release can no longer be cut from the
-tip: `v0.7.0` against a `main` reading `version = "1.0.0"` fails with
-`tag != pyproject 1.0.0`, dated changelog or not. Step 2 above assumes one
-version in flight; with several staged, tag the last commit that still reads the
-older version, `e1713c4` for 0.7.0:
+`pyproject.toml` **of the commit the tag points at**, so what you can cut depends
+on what that file reads.
+
+`pyproject.toml` on `main` tracks the newest **published** release, currently
+`0.6.0`, not the newest staged one. That is deliberate: a `version` nobody can
+`pip install` breaks `CITATION.cff`, the Zenodo deposit and the JOSS archive
+step, all of which have to name a release that exists.
+
+So cutting the next release is the normal path: branch, bump, date, tag.
 
 ```bash
-git switch -c release/0.7.0 e1713c4
+git switch -c release/0.7.0 main
+# step 2: bump `version` in pyproject.toml to 0.7.0
 # step 3: date the '## [0.7.0]' heading in CHANGELOG.md
-git commit -am "chore: date the 0.7.0 release"
+git commit -am "chore: release 0.7.0"
 git push origin release/0.7.0 && git tag v0.7.0 && git push origin v0.7.0
 ```
+
+The trap to know about: if someone bumps `pyproject.toml` on the tip to a
+*later* version than the one you are cutting, the older release can no longer be
+tagged from the tip, because `v0.7.0` against a tip reading `version = "1.0.0"`
+fails with `tag != pyproject 1.0.0`, dated changelog or not. In that case tag the
+last commit that still reads the version you want. Keeping `main` at the
+published version, as above, avoids the situation entirely.
 
 The branch is not a fork of the release pipeline. A `release` event only fires
 for a workflow file that "exists on the default branch", so `publish.yml` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "philanthropy"
-version = "1.0.0"
+version = "0.6.0"
 description = "scikit-learn-native predictive analytics for nonprofit and academic-medical-center fundraising: donor propensity, lapse, planned giving, wealth screening, and revenue forecasting."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Closes #88, taking the roll-back option.

## What was wrong

| Source | Said | Reality |
|---|---|---|
| `pyproject.toml:7` | `1.0.0` | no such tag, no PyPI artifact, no Zenodo deposit |
| `CITATION.cff:14` | `1.0.0` | same |
| `CITATION.cff:15` | released `2026-08-01` | that is **0.6.0's** release date |
| `CITATION.cff` DOI comment | cites the v0.6.0 per-version DOI | while the file above it claimed 1.0.0 |
| PyPI / newest tag | `0.6.0` | the version that actually exists |
| `SECURITY.md:11` | supports `0.6.x` | correct, and therefore contradicted by the above |

`CITATION.cff` was asserting a release that does not exist, in the file whose entire job is telling people what to cite.

## The fix

`pyproject.toml` and `CITATION.cff` both read `0.6.0`, and the DOI comment now states the rule rather than leaving it implicit: **`version` tracks the newest published release, not `main`.** A version nobody can `pip install` breaks `CITATION.cff`, the Zenodo deposit and the JOSS archive step, all of which have to name a release that exists.

`main` keeps carrying the unreleased `0.7.0` and `1.0.0` work, and those CHANGELOG headings stay `- TBD` until a release is cut. Nothing is reverted; only the metadata claim changes.

## One knock-on that had to come with it

`RELEASING.md` had a section, "Cutting a release `main` has already moved past", built entirely on the premise that the tip carries the newest *staged* version. It walked you through finding an older commit to tag, with `e1713c4` as the worked example, and warned that `v0.7.0` against a tip reading `version = "1.0.0"` fails.

That premise is now gone. With the tip at the published version, cutting 0.7.0 is the ordinary branch, bump, date, tag. The section documents that, and keeps the tag-an-older-commit case as the caveat it actually is.

Leaving the old example would have been a runbook describing a situation that no longer exists, which is the same defect several other commits this cycle went after. It also matters more than most docs drift, because it is the page you follow while holding release credentials.

## Verification

    make lint typecheck doctest   # exit 0
    full suite via the pre-push hook: 1817 passed

## Note on sequencing

This deliberately does **not** tag, publish, or mint a DOI. Those need PyPI and Zenodo credentials and are yours. The three Tier 1 output changes that had to land before any `v1.0.0` tag (#99, #100, #102) are all on `main` already, so whenever you do cut 1.0.0, that constraint is satisfied.
