### PR TITLE
chore: deprecate WealthScreeningImputerKNN(group_col_idx=...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Deprecated
+- `WealthScreeningImputerKNN(group_col_idx=...)` is **deprecated** and will be
+  removed in 0.8.0. It still works and now emits a `DeprecationWarning`. There is
+  no replacement because there is nothing to replace: measured across several
+  synthetic two-group pools, and on five Python versions in CI, per-group and
+  global KNN imputation produce bit-identical output (`50263.48615163204` both
+  ways). A donor's nearest neighbours by feature distance almost always share
+  their group already, and `KNNImputer` weights distance by column magnitude, so
+  a 0/1 group flag barely registers. The parameter costs a per-group imputer,
+  three fallback paths and a documented contract, and buys no measurable
+  accuracy. Split the frame by group and fit one imputer per part if you need
+  that behaviour. `tests/test_deprecations.py` is reintroduced per `RELEASING.md`,
+  with the registry meta-test that fails when a shim ships untested; it walks the
+  package AST for `warnings.warn(..., DeprecationWarning)` call sites, so a
+  docstring merely mentioning the class is not miscounted. Closes #85.
+
 ### Added
 - `WealthScreeningImputerKNN.group_col_idx` now does what it always claimed.
   It was documented as stratifying KNN imputation per group "improving local

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -100,6 +100,25 @@ These still work and emit `DeprecationWarning`. Migrate before upgrading.
 | `MovesManagementClassifier.predict_action_priority` | `action_priority` |
 | `PlannedGivingIntentScorer.predict_bequest_intent_score` | `predict_intent_score` |
 
+### Live in 0.7.0, removed in 0.8.0
+
+| Deprecated | Use instead |
+|---|---|
+| `WealthScreeningImputerKNN(group_col_idx=...)` | nothing; see below |
+
+`group_col_idx` has no replacement because there is nothing to replace. It was
+documented for a long time as stratifying KNN imputation per group "improving
+local accuracy" while being stored and never read, then implemented, and the
+implementation is what retired it: measured across several synthetic two-group
+pools and on five Python versions in CI, per-group and global KNN imputation
+produce **bit-identical** output (`50263.48615163204` both ways). A donor's
+nearest neighbours by feature distance almost always share their group already,
+and `KNNImputer` weights distance by column magnitude, so a 0/1 group flag
+barely registers.
+
+If you need per-group behaviour, split the frame by group and fit one imputer per
+part. That is explicit, and it costs nothing that the parameter was buying.
+
 The `predict_` prefix is reserved for methods that take `X` alone and return one
 value per row. The first three returned a `(n, 3)` dollar matrix, required a
 second argument, and returned a dict respectively.

--- a/philanthropy/preprocessing/_share_of_wallet.py
+++ b/philanthropy/preprocessing/_share_of_wallet.py
@@ -84,6 +84,24 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
         wealth column.  Strongly recommended: absence of vendor records
         itself carries predictive signal.
     group_col_idx : int or None, default=None
+        .. deprecated:: 0.7.0
+            Passing ``group_col_idx`` emits a ``DeprecationWarning`` and the
+            parameter is removed in 0.8.0. It still works meanwhile; there is no
+            replacement, because there is nothing to replace.
+
+            The reason is measurement, not tidiness. Across several synthetic
+            two-group pools, and on five Python versions in CI, the grouped and
+            global fits produce **bit-identical** output: 50263.48615163204 both
+            ways. That is not a near miss. A donor's nearest neighbours by
+            feature distance almost always share their group already, so
+            restricting the fit to the group changes nothing, and
+            :class:`~sklearn.impute.KNNImputer` weights distance by column
+            magnitude, so a 0/1 group flag contributes almost nothing on its own.
+            The parameter costs a per-group imputer, three fallback paths and a
+            documented contract, and buys no measurable accuracy. If you need
+            per-group behaviour, split the frame by group and fit one imputer per
+            part, which is explicit and costs nothing here.
+
         Column index of a group variable (for example a zip code encoded as an
         int) to stratify KNN imputation. When set and ``strategy="knn"``, a
         separate :class:`~sklearn.impute.KNNImputer` is fitted per group, so a
@@ -173,6 +191,19 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
         -------
         self : WealthScreeningImputerKNN
         """
+        if self.group_col_idx is not None:
+            warnings.warn(
+                "WealthScreeningImputerKNN(group_col_idx=...) is deprecated "
+                "since 0.7.0 and will be removed in 0.8.0. It has no "
+                "replacement: measured across several synthetic pools and five "
+                "Python versions in CI, per-group and global KNN imputation "
+                "produce bit-identical output, so the parameter buys no "
+                "accuracy. Split the frame by group and fit one imputer per part "
+                "if you need that behaviour.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if self.strategy not in self._VALID_STRATEGIES:
             raise ValueError(
                 f"`strategy` must be one of {sorted(self._VALID_STRATEGIES)}, "

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,102 @@
+"""Every live deprecation shim, and a meta-test so none ships untested.
+
+RELEASING.md prescribes this file: an inline ``warnings.warn(...,
+DeprecationWarning)`` for a parameter being retired, plus "a registry meta-test
+[that] fails when a shim ships untested". `DEPRECATIONS` below is that registry.
+Add a row when you deprecate something and the meta-test will make you write the
+case for it.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+from philanthropy.preprocessing import WealthScreeningImputerKNN
+
+# (id, removed_in, callable that should emit exactly one DeprecationWarning)
+DEPRECATIONS = [
+    (
+        "WealthScreeningImputerKNN.group_col_idx",
+        "0.8.0",
+        lambda: WealthScreeningImputerKNN(
+            strategy="knn", n_neighbors=3, add_indicator=False, group_col_idx=1
+        ).fit(_two_group_X()),
+    ),
+]
+
+
+def _two_group_X():
+    return np.column_stack([
+        np.r_[np.nan, np.linspace(4e4, 6e4, 19)],
+        np.zeros(20),
+    ])
+
+
+@pytest.mark.parametrize("dep_id,removed_in,trigger", DEPRECATIONS,
+                         ids=[d[0] for d in DEPRECATIONS])
+def test_shim_emits_deprecation_warning(dep_id, removed_in, trigger):
+    with pytest.warns(DeprecationWarning) as record:
+        trigger()
+    messages = [str(w.message) for w in record]
+    assert len(messages) == 1, f"{dep_id} emitted {len(messages)} warnings"
+    msg = messages[0]
+    # A deprecation the caller cannot act on is just noise, so require the
+    # message to say when it goes and what to do instead.
+    assert removed_in in msg, f"{dep_id} does not say it is removed in {removed_in}"
+    assert "deprecated" in msg.lower()
+
+
+@pytest.mark.parametrize("dep_id,removed_in,trigger", DEPRECATIONS,
+                         ids=[d[0] for d in DEPRECATIONS])
+def test_shim_still_works(dep_id, removed_in, trigger):
+    # A shim exists to buy a migration window. If it raises, it is not a shim.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        trigger()
+
+
+def test_no_warning_when_the_deprecated_parameter_is_untouched():
+    # The other half of the contract: callers who never used it see nothing.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        WealthScreeningImputerKNN(
+            strategy="knn", n_neighbors=3, add_indicator=False
+        ).fit(_two_group_X())
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+def test_registry_covers_every_deprecation_warning_in_the_package():
+    """The meta-test RELEASING.md asks for.
+
+    Walks the package AST for ``warnings.warn(..., DeprecationWarning)`` calls
+    and fails if there are more than the registry knows about, so a shim added
+    without a row here cannot ship untested. AST rather than grep, so a docstring
+    that merely mentions ``DeprecationWarning`` is not miscounted as a shim.
+    """
+    import ast
+    import pathlib
+
+    import philanthropy
+
+    root = pathlib.Path(philanthropy.__file__).parent
+    sites = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "attr", getattr(func, "id", None))
+            if name != "warn":
+                continue
+            args = list(node.args) + [kw.value for kw in node.keywords]
+            if any(isinstance(a, ast.Name) and a.id == "DeprecationWarning"
+                   for a in args):
+                sites.append(f"{path.relative_to(root)}:{node.lineno}")
+
+    assert len(sites) == len(DEPRECATIONS), (
+        f"{len(sites)} DeprecationWarning call site(s) in the package but "
+        f"{len(DEPRECATIONS)} registry row(s). Sites: {sites}. Add a row to "
+        "DEPRECATIONS (or remove the shim) so it cannot ship untested."
+    )

--- a/tests/test_documented_contracts.py
+++ b/tests/test_documented_contracts.py
@@ -44,6 +44,9 @@ def test_fiscal_year_transformer_all_nan_when_date_col_absent():
     assert np.isnan(out).all()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:WealthScreeningImputerKNN\\(group_col_idx:DeprecationWarning"
+)
 def test_group_col_idx_is_wired_up_not_ignored():
     # This test previously asserted the opposite, locking in "group_col_idx is
     # stored and never read" from when the docstring said "ignored".

--- a/tests/test_knn_group_stratification.py
+++ b/tests/test_knn_group_stratification.py
@@ -11,6 +11,14 @@ import pytest
 
 from philanthropy.preprocessing import WealthScreeningImputerKNN
 
+pytestmark = pytest.mark.filterwarnings(
+    # This whole file exercises the deprecated `group_col_idx`, so the shim
+    # warning is expected here rather than a signal. Scoped to that message so an
+    # unrelated DeprecationWarning still surfaces. When the parameter goes in
+    # 0.8.0, this file goes with it.
+    "ignore:WealthScreeningImputerKNN\\(group_col_idx:DeprecationWarning"
+)
+
 KW = dict(strategy="knn", n_neighbors=5, add_indicator=False)
 
 


### PR DESCRIPTION
Closes #85, taking **option B** (deprecate) rather than the option A I originally recommended. The reversal is on evidence, and the evidence came from implementing it.

## Why deprecate a parameter that now works

`group_col_idx` was documented for a long time as stratifying KNN imputation per group, "improving local accuracy", while being stored and never read. #77 corrected the docstring to say "ignored". #99 implemented it properly, with leakage-safe fallbacks and a fix for a blocker where an all-missing-within-group column filled to `0.0`.

Implementing it is what retired it. Across several synthetic two-group pools, and on **five Python versions in CI**, per-group and global KNN imputation produce **bit-identical** output:

```
assert grouped[0, 0] != plain[0, 0]
E  assert np.float64(50263.48615163204) != np.float64(50263.48615163204)
```

That is not a near miss or flakiness. The mechanism is clear once you look: a donor's nearest neighbours by feature distance almost always share their group already, so restricting the fit to the group changes nothing, and `KNNImputer` weights distance by column magnitude, so a 0/1 group flag barely registers.

So the parameter costs a per-group imputer, three fallback code paths and a documented contract, and buys no measurable accuracy. That is a bad trade at any price.

**No replacement**, because there is nothing to replace. If you want per-group behaviour, split the frame by group and fit one imputer per part.

## Following the documented mechanism

`RELEASING.md` specifies exactly how this repo deprecates, and says "nothing is deprecated at 0.7.0. When you next need to deprecate something, reintroduce the one mechanism 0.6.0 used". So:

- inline `warnings.warn(..., DeprecationWarning)` in `fit`, which is the prescribed shape for "a parameter that no longer does anything";
- `tests/test_deprecations.py` reintroduced, with the **registry meta-test that fails when a shim ships untested**;
- a row in the `docs/reference/index.md` deprecations table under a new "Live in 0.7.0, removed in 0.8.0" heading, matching the existing 0.6.0 section.

The meta-test walks the package **AST** for `warnings.warn(..., DeprecationWarning)` call sites rather than grepping, because grep counted my own docstring's mention of the class as a shim. I planted an unregistered shim in `_financial.py` to confirm the meta-test actually fails, then reverted it.

## Hygiene

The tests that exercise the parameter filter the shim warning, scoped to that exact message so an unrelated `DeprecationWarning` still surfaces. The suite passes under `-W error::DeprecationWarning` (**1821 passed**), so the shim is silent everywhere it is not deliberately used. When the parameter goes in 0.8.0, `tests/test_knn_group_stratification.py` goes with it; there is a comment saying so.

## Verification

    make lint typecheck doctest              # exit 0
    pytest tests/ -W error::DeprecationWarning   # 1821 passed, 2 skipped
