### PR TITLE
Ignore local working notes under .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ site/
 # Local working notes (not published)
 plan.md
 .outreach-todo.md
+.claude/CLAUDE.local.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   An agent may now merge a PR under the same bar as the maintainer's own-PR
   merge (all required CI checks green, no second reviewer available), plus
   having actually read the diff and judged it good.
+- `.gitignore` now excludes `.claude/CLAUDE.local.md`, for personal working
+  notes that shouldn't end up in the repo.
 
 ### Fixed
 - Version metadata now names the release that actually exists. `pyproject.toml`


### PR DESCRIPTION
Same idea as `plan.md` / `.outreach-todo.md` above in `.gitignore`: personal
scratch notes that live in the working tree but shouldn't be committed.

## Checklist
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Already listed in `CONTRIBUTORS.md`
- [x] No code touched