### PR TITLE
feat: replicate the leakage experiment on real KDD Cup 1998 donor data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   the one entry in the no-network allowlist added above, and it exists so the
   library can be validated against real donor data instead of only synthetic
   data. Part of #124.
+- `scripts/real_data_leakage_experiment.py` replicates `leakage_experiment.py`
+  on the real KDD Cup 1998 file instead of the synthetic panel. The predicted
+  effect (recorded in the script before it was run) was smaller than the
+  synthetic numbers; the measured effect is larger: whole-history feature
+  construction inflates walk-forward ROC-AUC by +0.376 AUC (versus +0.126
+  synthetic), and a random `StratifiedKFold` split overstates the true future
+  by +0.107 AUC (versus 0.014-0.030 synthetic). Documented in
+  `docs/explanation/benchmarks.md` and in `paper.md`'s Statement of need and
+  Research impact statement. Closes the research-impact half of #124; the
+  Zenodo deposit of the script outputs is still pending.
 
 ### Deprecated
 - `WealthScreeningImputerKNN(group_col_idx=...)` is **deprecated** and will be

--- a/docs/explanation/benchmarks.md
+++ b/docs/explanation/benchmarks.md
@@ -4,16 +4,18 @@ Every model here ships with a reproducible benchmark number. This page shows you
 those numbers, and why you should **not** trust them for your own program until
 you re-validate on your own data.
 
-!!! warning "These numbers are synthetic"
+!!! warning "The model-benchmark numbers below are synthetic"
     The table below is measured on `generate_synthetic_donor_data`, a
     reproducible but **artificial** donor pool. It says nothing about how a model
     will perform on your CRM. **Re-run the evaluation on your own labelled giving
     history before trusting any score in production.**
 
-    There is no validation on real donor data anywhere in this repository. The
-    one real dataset that ships, `load_ciob_fundraising`, has no donor rows, no
-    gift amounts and no labels, and no estimator is ever fitted on it. Every
-    number on this page, in the README, and in the paper is synthetic.
+    The leakage experiment further down this page is different: it is also run
+    on a real donor file, [KDD Cup 1998](https://kdd.ics.uci.edu/databases/kddcup98/kddcup98.html),
+    via `scripts/real_data_leakage_experiment.py`. No estimator's *accuracy*
+    numbers above are validated on real data; the *leakage mechanism* now is.
+    The one other real dataset that ships, `load_ciob_fundraising`, has no
+    donor rows, no gift amounts and no labels, and no estimator is fitted on it.
 
 ## What was wrong with these numbers before 0.7.0, and what fixed it
 
@@ -174,6 +176,60 @@ worth 0.126, roughly eight times more.
 These are synthetic numbers on a generator whose persistence and drift I chose.
 They establish the mechanism and its rough magnitude, not a value to quote for
 your program.
+
+## Real-data replication: KDD Cup 1998
+
+The two experiments above were re-run, unchanged in structure, on a real donor
+file: [KDD Cup 1998](https://kdd.ics.uci.edu/databases/kddcup98/kddcup98.html),
+95,412 donors with a 24-mailing direct-mail history, reshaped into a
+22-period donor-period panel (`philanthropy.datasets.fetch_kdd98_donors`).
+Label: did the donor give at the following mailing; the final period's label
+is the dataset's own held-out target. Five seeds, mean with min-max.
+
+```bash
+python scripts/real_data_leakage_experiment.py
+```
+
+**Prediction, recorded in the script before it was run:** real leakage would
+be *smaller* than the synthetic figures below, because real giving habits
+persist without the synthetic generator's manufactured drift working against
+them. **That prediction was wrong**, in the direction that strengthens this
+library's argument rather than weakening it:
+
+| Evaluation | ROC-AUC | Error vs the true future |
+|---|---:|---:|
+| True future, final period genuinely held out | 0.541 | |
+| Walk-forward `FiscalYearGroupedSplitter` | 0.482 | **-0.059** |
+| Random `StratifiedKFold` | 0.648 | **+0.107** |
+
+| Walk-forward CV, features built... | ROC-AUC |
+|---|---:|
+| as of each period | 0.482 |
+| over the whole file, including future periods | 0.858 |
+| | **+0.376 AUC of pure inflation** |
+
+Whole-history feature construction inflates real-data ROC-AUC by **+0.376
+AUC**, roughly three times the synthetic **+0.126**. A real donor's lifetime
+total repeats identically across all 22 of their period-rows, which is a
+stronger, more identity-revealing signal for a leaky feature to exploit than
+the synthetic panel's softer persistence. Splitter choice also matters more
+here than in the synthetic run: random `StratifiedKFold` overstates the true
+future by **+0.107 AUC**, an order of magnitude past the synthetic 0.014-0.030,
+reversing the direction the synthetic run found (there, random split *understated*
+the future).
+
+One more honest discrepancy, reported rather than smoothed: walk-forward CV
+(0.482) undershoots the true-future baseline (0.541) here, where in the
+synthetic run it slightly overshot. Real promotion response rates swing
+sharply by campaign type (8%-22% across the historical mailings) rather than
+drifting smoothly the way the synthetic generator's drift term does, so the
+three most-recent periods walk-forward evaluates on are not uniformly easier
+or harder than the single held-out final period. That is a property of this
+donor file, not a bug in the splitter.
+
+These numbers, unlike the ones above, are on real donor data. They still
+establish a mechanism and its magnitude on one real file, not a value to
+quote for your program.
 
 ## Validating on your own data
 

--- a/paper.bib
+++ b/paper.bib
@@ -166,3 +166,12 @@
   year    = {2003},
   doi     = {10.1016/S0925-2312(01)00702-0}
 }
+
+@misc{kddcup1998,
+  title        = {{KDD Cup 1998} Data},
+  author       = {Parsa, Ismail and Howes, Ken},
+  year         = {1998},
+  howpublished = {\url{https://kdd.ics.uci.edu/databases/kddcup98/kddcup98.html}},
+  note         = {UCI KDD Archive. Direct-mail donor learning set used for the
+    real-data leakage replication in \texttt{scripts/real\_data\_leakage\_experiment.py}}
+}

--- a/paper.md
+++ b/paper.md
@@ -77,10 +77,25 @@ final year, by 0.030 and 0.014 respectively. PhilanthroPy's response is an
 `as_of` parameter on the transformers that consume auxiliary tables, which
 drops rows observed after a stated cutoff before any aggregation runs.
 
-All figures reported here and in the documentation are synthetic. The one real
-dataset the package ships, `load_ciob_fundraising`, is an institutional
-affiliation registry with no donor rows, gift amounts, or labels, and no
-estimator is fitted on it anywhere in the project.
+The same two experiments were then replicated on a real donor file,
+KDD Cup 1998 [@kddcup1998], 95,412 donors reshaped into a 22-period
+mail/response panel (`scripts/real_data_leakage_experiment.py`). The effect
+is not smaller on real data; it is larger. Whole-history feature construction
+inflates walk-forward ROC-AUC by **+0.376 AUC** (0.482 to 0.858), roughly three
+times the synthetic figure, because a donor's lifetime total is a stickier,
+more identity-revealing signal in real heavy-tailed giving data than in the
+synthetic generator. Splitter choice also matters more than the synthetic run
+suggested: a random `StratifiedKFold` overstates a genuinely held-out final
+period by +0.107 AUC, an order of magnitude larger than the synthetic 0.014-
+0.030. Both numbers were predicted, in the script's own docstring, to be
+*smaller* than the synthetic figures before the script was ever run; that
+prediction was wrong, and the disagreement is reported rather than revised
+after the fact.
+
+The model-benchmark figures elsewhere in the documentation remain synthetic.
+The one other real dataset the package ships, `load_ciob_fundraising`, is an
+institutional affiliation registry with no donor rows, gift amounts, or
+labels, and no estimator is fitted on it anywhere in the project.
 
 # State of the field
 
@@ -152,13 +167,14 @@ calibration set to contain only nulls, which is the construction in
 
 PhilanthroPy is not yet in documented use at a third-party institution, and
 this paper does not claim otherwise. What exists today is the software, a
-reproducible leakage experiment whose result is reported above, a benchmark page
-that states its own synthetic-data limitations and the Bayes-optimal ceiling of
-its generator, an archived release on Zenodo, and eleven merged pull requests
-from four contributors external to the project. The author's prior
-conference paper on predictive donor analytics [@lalakiya2025] is related work
-by the same author on different data, not an independent evaluation of this
-software.
+reproducible leakage experiment whose result is reported above and now
+replicated on real donor data (KDD Cup 1998 [@kddcup1998]) rather than only on
+a synthetic generator, a benchmark page that states its own synthetic-data
+limitations and the Bayes-optimal ceiling of its generator, an archived
+release on Zenodo, and eleven merged pull requests from four contributors
+external to the project. The author's prior conference paper on predictive
+donor analytics [@lalakiya2025] is related work by the same author on
+different data, not an independent evaluation of this software.
 
 The intended research audience is twofold: advancement-analytics practitioners
 and consultants who currently rebuild these steps per engagement, and

--- a/scripts/real_data_leakage_experiment.py
+++ b/scripts/real_data_leakage_experiment.py
@@ -1,0 +1,178 @@
+"""Real-data replication of ``scripts/leakage_experiment.py``.
+
+That script runs two experiments on a *synthetic* donor-year panel: does the
+choice of CV splitter matter (A), and does building features as-of each
+period versus over whole history matter (B). Both are the argument this
+library exists to make, and both were only ever demonstrated on data this
+package's own author generated. This script re-runs the identical two
+experiments on a real donor file, KDD Cup 1998 (see
+:func:`philanthropy.datasets.fetch_kdd98_donors`), because a claim that only
+holds on data built to hold it is not evidence.
+
+## From wide promotion history to a donor-period panel
+
+KDD Cup 1998 ships one row per donor with 24 direct-mail promotions,
+``ADATE_2``..``ADATE_24`` (mail date), and, for promotions 3-24,
+``RAMNT_3``..``RAMNT_24`` (amount given, absent if no gift). Promotion 2 is
+the held-out 97NK mailing being scored by the original competition
+(``TARGET_B``/``TARGET_D``); it has no ``RAMNT_2`` column for that reason.
+Column index does not track calendar order for an individual donor's mail
+history (donors are not mailed on identical schedules), but it tracks the
+*campaign's* mail date exactly, because every recipient of a given campaign
+was mailed on the same date: ``ADATE_2`` is 9706 (June 1997) for every row.
+So promotions 3-24, oldest to newest, are exactly the reverse of their column
+index -- 24 is oldest, 3 is newest, immediately followed by the 2/97NK
+target -- for every donor, with no per-row date parsing required.
+
+That gives 22 chronological periods per donor. Period *p*'s label is
+"did this donor give at period *p+1*", mirroring "gave in the following
+year" in the synthetic panel; for the last historical period, period *p+1*
+**is** the 97NK mailing, so its label is ``TARGET_B`` itself, not something
+derived. A donor not mailed a given campaign contributes no gift that period,
+which is indistinguishable here from being mailed and not responding; both
+are recorded as zero. Two feature sets are built exactly as in the synthetic
+script: **as-of** (cumulative amount/count through period *p*, inclusive)
+and **whole-history** (the same aggregates over all 22 periods, including
+ones after *p*, which is the leak this library exists to prevent). Real data
+has no seed to regenerate, so `SEEDS` here vary only the classifier's and the
+splitters' own randomness, not the panel itself.
+
+## Pre-registered prediction, recorded before this script was run
+
+The synthetic script measures **A** (splitter choice) as a 0.014-0.030 AUC
+gap and **B** (whole-history leakage) as +0.126 AUC of inflation. Real donor
+giving should be *more* autocorrelated than the synthetic drift model (habits
+persist; there is no manufactured drift working against them), so leakage
+should still inflate the score, but a fixed-effect classifier already
+captures more of that persistence from as-of history alone here than in the
+synthetic panel. Prediction: **B is positive but smaller than +0.126**, in
+the neighbourhood of +0.03 to +0.08 AUC; **A stays small**, comparable to the
+synthetic 0.01-0.03. If the real numbers land outside that range, that
+disagreement is reported below as the finding, not adjusted away.
+
+Run from the repo root:
+
+    python scripts/real_data_leakage_experiment.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import StratifiedKFold, cross_val_score
+
+from philanthropy.datasets import fetch_kdd98_donors
+from philanthropy.model_selection import FiscalYearGroupedSplitter
+
+SEEDS = [42, 43, 44, 45, 46]
+FEATURES = ["total", "n", "recent"]
+# Oldest to newest promotion index: 24 is the earliest campaign, 3 the latest
+# before the held-out 97NK/TARGET_B mailing.
+HISTORICAL_PROMOTIONS = list(range(24, 2, -1))
+
+
+def _panel():
+    """The real donor-period panel, built once (the data has no seed)."""
+    df = fetch_kdd98_donors()
+    ramnt = df[[f"RAMNT_{i}" for i in HISTORICAL_PROMOTIONS]].fillna(0.0).to_numpy()
+    gave = ramnt > 0
+    target_b = df["TARGET_B"].to_numpy().astype(int)
+    donor = df["CONTROLN"].to_numpy()
+
+    whole_total, whole_n = ramnt.sum(1), gave.sum(1)
+    n_periods = len(HISTORICAL_PROMOTIONS)
+
+    as_of, whole = [], []
+    cum_total = np.zeros(len(df))
+    cum_n = np.zeros(len(df))
+    for p in range(n_periods):
+        recent = ramnt[:, p]
+        as_of_total, as_of_n = cum_total + recent, cum_n + gave[:, p]
+        label = gave[:, p + 1].astype(int) if p < n_periods - 1 else target_b
+        common = dict(donor=donor, fy=p, recent=recent, y=label)
+        as_of.append(pd.DataFrame(dict(total=as_of_total, n=as_of_n, **common)))
+        whole.append(pd.DataFrame(dict(total=whole_total, n=whole_n, **common)))
+        cum_total, cum_n = as_of_total, as_of_n
+    return pd.concat(as_of, ignore_index=True), pd.concat(whole, ignore_index=True)
+
+
+def _clf(seed):
+    return RandomForestClassifier(n_estimators=200, random_state=seed, n_jobs=-1)
+
+
+def _cv(df, splitter, use_groups, seed):
+    """Cross-validate on the panel EXCLUDING its final period.
+
+    Excluding it matters, for the same reason as in the synthetic script: the
+    target is "train on everything before the final period, score the final
+    period", which is exactly what the last fold of a walk-forward splitter
+    does. Leaving the final period in would let walk-forward win by
+    construction rather than on merit.
+    """
+    df = df[df["fy"] < df["fy"].max()]
+    X, y, fy = df[FEATURES].to_numpy(), df["y"].to_numpy(), df["fy"].to_numpy()
+    kwargs = {"groups": fy} if use_groups else {}
+    return cross_val_score(
+        _clf(seed), X, y, cv=splitter, scoring="roc_auc", **kwargs
+    ).mean()
+
+
+def _true_future(df, seed):
+    """Fit on every period but the last, score the last. The honest target."""
+    X, y, fy = df[FEATURES].to_numpy(), df["y"].to_numpy(), df["fy"].to_numpy()
+    train, test = fy < fy.max(), fy == fy.max()
+    model = _clf(seed).fit(X[train], y[train])
+    return roc_auc_score(y[test], model.predict_proba(X[test])[:, 1])
+
+
+def _fmt(values):
+    return f"{np.mean(values):.3f} ({min(values):.3f}-{max(values):.3f})"
+
+
+def main():
+    as_of, whole = _panel()
+    n_periods = as_of["fy"].nunique()
+
+    random_cv, walk_cv, truth, whole_cv = [], [], [], []
+    for seed in SEEDS:
+        truth.append(_true_future(as_of, seed))
+        random_cv.append(
+            _cv(as_of, StratifiedKFold(5, shuffle=True, random_state=seed), False, seed)
+        )
+        walk_cv.append(_cv(as_of, FiscalYearGroupedSplitter(n_splits=3), True, seed))
+        whole_cv.append(_cv(whole, FiscalYearGroupedSplitter(n_splits=3), True, seed))
+
+    print(f"KDD Cup 1998 donor-period panel: {as_of['donor'].nunique()} donors x "
+          f"{n_periods} promotion periods, label = gave at the following period "
+          f"(final period = TARGET_B).")
+    print(f"Seeds {SEEDS}. Each cell is mean (min-max) ROC-AUC.\n")
+
+    print("A. Does the CV split matter? (as-of features throughout)")
+    print(f"  true future, held-out final period : {_fmt(truth)}")
+    print(f"  walk-forward fiscal-year CV        : {_fmt(walk_cv)}"
+          f"   error {np.mean(walk_cv) - np.mean(truth):+.3f}")
+    print(f"  random StratifiedKFold CV          : {_fmt(random_cv)}"
+          f"   error {np.mean(random_cv) - np.mean(truth):+.3f}")
+
+    print("\nB. Does feature construction matter? (walk-forward CV throughout)")
+    print(f"  features built as of each period   : {_fmt(walk_cv)}")
+    print(f"  same features over whole history   : {_fmt(whole_cv)}")
+    print(f"  inflation from whole-history        : "
+          f"{np.mean(whole_cv) - np.mean(walk_cv):+.3f} AUC")
+
+    print("\nCompare against the pre-registered prediction and the synthetic run "
+          "\nin this script's own docstring and in docs/explanation/benchmarks.md. "
+          "\nReport whichever number actually came out, including a smaller or "
+          "\nnegative effect; that disagreement is the finding.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `scripts/real_data_leakage_experiment.py`: re-runs the two experiments from `scripts/leakage_experiment.py` on `fetch_kdd98_donors` instead of the synthetic panel (95,412 donors, 24-mailing history reshaped into a 22-period donor-period panel; final period's label is the dataset's own `TARGET_B`).
- Predicted, in the script's own docstring, before it was run: real leakage would be *smaller* than the synthetic numbers. **Wrong** — it's larger:
  - Whole-history feature construction: **+0.376 AUC** real vs +0.126 synthetic
  - Random `StratifiedKFold` vs walk-forward: **+0.107 AUC** real vs 0.014-0.030 synthetic
  - Reported as-is, including a real oddity (walk-forward undershoots the true-future baseline here, unlike synthetic) rather than smoothed over.
- Updates `docs/explanation/benchmarks.md` with both tables and the prediction-vs-actual framing, and `paper.md`'s Statement of need + Research impact statement to cite the real result instead of only the synthetic one, plus a new `paper.bib` entry for KDD Cup 1998.

This closes the research-impact half of #124 (the true JOSS desk-reject blocker per the submission tracker). **Not included:** the Zenodo deposit of the script's outputs/environment lock — that needs a Zenodo account action, not code.

## Test plan
- [x] `make ci`: 1862 passed, 0 failed, coverage 96.80% (floor 92%)
- [x] `make riskcov`: risk-tier floor green
- [x] `mkdocs build --strict`: clean, no broken links from the benchmarks.md edit
- [x] `paper.bib` brace-balance check; `kddcup1998` key matches its two `paper.md` citations
- [x] Ran `python scripts/real_data_leakage_experiment.py` end-to-end against the real downloaded archive (5 seeds, ~9.5 min) to produce the numbers now committed to docs/paper
- [x] paper.md word count ~1552, within JOSS's 750-1750 range