### PR TITLE
chore: prep the 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,9 @@ work that ships for the first time in this release.
   synthetic), and a random `StratifiedKFold` split overstates the true future
   by +0.107 AUC (versus 0.014-0.030 synthetic). Documented in
   `docs/explanation/benchmarks.md` and in `paper.md`'s Statement of need and
-  Research impact statement. Closes the research-impact half of #124; the
-  Zenodo deposit of the script outputs is still pending.
+  Research impact statement. The script outputs and environment lock are
+  archived on Zenodo (DOI [10.5281/zenodo.22050649](https://doi.org/10.5281/zenodo.22050649)).
+  Closes #124.
 
 ### Deprecated
 - `WealthScreeningImputerKNN(group_col_idx=...)` is **deprecated** and will be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [1.0.0] - TBD
+
+The API freeze. No code changes: 1.0.0 is a promise, not a feature.
+
+### Changed
+- `Development Status :: 5 - Production/Stable`.
+- **Tier 1 is now semver-protected.** A breaking change to any Tier 1 symbol
+  requires a major release, preceded by one full published minor emitting
+  `DeprecationWarning`. Tier 2 may still break in a minor; Tier 3 carries no
+  guarantee. The tiers are listed per-symbol in
+  [docs/reference/index.md](docs/reference/index.md).
+
+### Added
+- `test_stability_tier_table_covers_every_public_symbol`: the tier table is now
+  machine-checked against `__all__`, so a new public symbol cannot ship without
+  a stated tier. At 1.0 that table is the contract; an out-of-date one is a
+  broken promise, not a docs nit.
+
+### Notes
+The five 1.0 gates all hold at this commit: 0.7.0 published; the public-API
+contract test green with no exemption added since 0.7.0; no `deprecated_alias`
+anywhere in `philanthropy/`; `__version__ == importlib.metadata.version(...)`
+and `py.typed` in the wheel; every `__all__` symbol carries a tier and no Tier 1
+entry is mid-deprecation.
+
+## [0.7.0] - 2026-08-21
+
+The removal release, plus everything else merged since 0.6.0. Every shim
+under Breaking shipped in 0.6.0 emitting a `DeprecationWarning` for one full
+published minor; everything under Added, Changed and Deprecated below is new
+work that ships for the first time in this release.
+
+### Breaking
+- **Four deprecated method aliases removed.** Use the replacement in every case:
+
+  | Removed | Use instead |
+  |---|---|
+  | `AskAmountRecommender.predict_ask_array` | `ask_ladder` |
+  | `ShareOfWalletRegressor.predict_capacity_ratio` | `capacity_ratio` |
+  | `MovesManagementClassifier.predict_action_priority` | `action_priority` |
+  | `PlannedGivingIntentScorer.predict_bequest_intent_score` | `predict_intent_score` |
+
+- **Three dead constructor parameters removed.** Passing any of them is now a
+  `TypeError`: `LapsePredictor(lapse_window_years=...)` (the window is a
+  property of how you labelled `y`), `PropensityScorer(estimator=...)` (the
+  baseline is a constant 0.5), `FiscalYearGroupedSplitter(fiscal_year_start=...)`
+  (`groups` already carries fiscal-year labels).
+- **`donor_acquisition_cost`, `cost_per_dollar_raised` and `fundraising_roi` are
+  keyword-only.** They do not share an argument order:
+  `cost_per_dollar_raised` takes expense first, `fundraising_roi` takes raised
+  first, so a positional call was silently accepted and returned a plausible
+  wrong number. It is now a `TypeError`.
+- **Four accidental second import paths moved behind underscores** so 1.0 does
+  not freeze them: `metrics.scoring` → `metrics._scoring`,
+  `preprocessing.transformers` → `preprocessing._transformers`,
+  `models.propensity` → `models._propensity_baseline`, `utils.testing` →
+  `utils._testing`. Every public symbol is unchanged and still exported from its
+  subpackage; only a direct `from philanthropy.metrics.scoring import ...`
+  breaks. Import from the subpackage instead.
+- `philanthropy/utils/_deprecation.py` is gone. `tests/test_deprecations.py`,
+  which existed solely to police the shims removed above, went with it, then
+  came back later in this same release to police a new one; see Deprecated
+  below.
+
 ### Changed
 - `GratefulPatientFeaturizer`, `EncounterTransformer` and the `philanthropy`
   CLI now reject network-scheme paths (`https://`, `s3://`, `gs://`) with a
@@ -592,68 +656,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Recency is anchored to `reference_date` or the batch's latest gift, never a
   moving "now", the same leakage contract as the UniSchema bridge. See
   [docs/how-to/ingest_civicrm_contributions.md](docs/how-to/ingest_civicrm_contributions.md).
-
-## [1.0.0] - TBD
-
-The API freeze. No code changes: 1.0.0 is a promise, not a feature.
-
-### Changed
-- `Development Status :: 5 - Production/Stable`.
-- **Tier 1 is now semver-protected.** A breaking change to any Tier 1 symbol
-  requires a major release, preceded by one full published minor emitting
-  `DeprecationWarning`. Tier 2 may still break in a minor; Tier 3 carries no
-  guarantee. The tiers are listed per-symbol in
-  [docs/reference/index.md](docs/reference/index.md).
-
-### Added
-- `test_stability_tier_table_covers_every_public_symbol`: the tier table is now
-  machine-checked against `__all__`, so a new public symbol cannot ship without
-  a stated tier. At 1.0 that table is the contract; an out-of-date one is a
-  broken promise, not a docs nit.
-
-### Notes
-The five 1.0 gates all hold at this commit: 0.7.0 published; the public-API
-contract test green with no exemption added since 0.7.0; no `deprecated_alias`
-anywhere in `philanthropy/`; `__version__ == importlib.metadata.version(...)`
-and `py.typed` in the wheel; every `__all__` symbol carries a tier and no Tier 1
-entry is mid-deprecation.
-
-## [0.7.0] - TBD
-
-The removal release. Every shim below shipped in 0.6.0 emitting a
-`DeprecationWarning` for one full published minor.
-
-### Breaking
-- **Four deprecated method aliases removed.** Use the replacement in every case:
-
-  | Removed | Use instead |
-  |---|---|
-  | `AskAmountRecommender.predict_ask_array` | `ask_ladder` |
-  | `ShareOfWalletRegressor.predict_capacity_ratio` | `capacity_ratio` |
-  | `MovesManagementClassifier.predict_action_priority` | `action_priority` |
-  | `PlannedGivingIntentScorer.predict_bequest_intent_score` | `predict_intent_score` |
-
-- **Three dead constructor parameters removed.** Passing any of them is now a
-  `TypeError`: `LapsePredictor(lapse_window_years=...)` (the window is a
-  property of how you labelled `y`), `PropensityScorer(estimator=...)` (the
-  baseline is a constant 0.5), `FiscalYearGroupedSplitter(fiscal_year_start=...)`
-  (`groups` already carries fiscal-year labels).
-- **`donor_acquisition_cost`, `cost_per_dollar_raised` and `fundraising_roi` are
-  keyword-only.** They do not share an argument order:
-  `cost_per_dollar_raised` takes expense first, `fundraising_roi` takes raised
-  first, so a positional call was silently accepted and returned a plausible
-  wrong number. It is now a `TypeError`.
-- **Four accidental second import paths moved behind underscores** so 1.0 does
-  not freeze them: `metrics.scoring` → `metrics._scoring`,
-  `preprocessing.transformers` → `preprocessing._transformers`,
-  `models.propensity` → `models._propensity_baseline`, `utils.testing` →
-  `utils._testing`. Every public symbol is unchanged and still exported from its
-  subpackage; only a direct `from philanthropy.metrics.scoring import ...`
-  breaks. Import from the subpackage instead.
-- `philanthropy/utils/_deprecation.py` is gone: nothing is deprecated at 0.7.0.
-
-### Removed
-- `tests/test_deprecations.py`, which existed solely to police the shims.
 
 ## [0.6.0] - 2026-08-01
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,17 +12,18 @@ authors:
     given-names: "Shivam Ashokbhai"
     orcid: "https://orcid.org/0009-0000-5110-6540"
     email: shivamlalakiya151299@gmail.com
-version: 0.6.0
-date-released: "2026-08-01"
+version: 0.7.0
+date-released: "2026-08-21"
 license: MIT
 repository-code: "https://github.com/PhilanthroPy-Project/PhilanthroPy"
 url: "https://PhilanthroPy-Project.github.io/PhilanthroPy/"
 # Zenodo concept DOI: always resolves to the latest deposited release. This is
-# deliberately NOT the per-version DOI, which for this release (0.6.0) is
-# 10.5281/zenodo.21751097. Cite the concept DOI so the reference does not go
-# stale. `version` above tracks the newest PUBLISHED release, not `main`:
-# main carries unreleased 0.7.0 and 1.0.0 work, and citing a version nobody
-# can install is worse than citing one release behind.
+# deliberately NOT the per-version DOI: 0.6.0's was 10.5281/zenodo.21751097,
+# and 0.7.0 gets its own once the GitHub release triggers a new Zenodo
+# deposit. Cite the concept DOI so the reference does not go stale.
+# `version` above tracks the newest PUBLISHED release, not `main`: main
+# carries unreleased 1.0.0 work, and citing a version nobody can install is
+# worse than citing one release behind.
 identifiers:
   - type: doi
     value: "10.5281/zenodo.21751096"

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ One toolkit, two audiences:
 
 ### Maturity
 
-Single-maintainer MIT project. **`pip install philanthropy` gives you `0.6.0`**, the current release.
+Single-maintainer MIT project. **`pip install philanthropy` gives you `0.7.0`**, the current release.
 
-`main` is ahead of it: `0.7.0` (removes the `0.6.0` deprecations) and `1.0.0` (freezes the API) are merged and green but deliberately unreleased, so the `0.6.0` deprecation warnings get a real migration window rather than a token one. Read the [CHANGELOG](CHANGELOG.md) for what is queued.
+`main` is ahead of it: `1.0.0` (freezes the API) is merged and green but deliberately unreleased, so 0.7.0 gets a real usage window before that promise takes effect. Read the [CHANGELOG](CHANGELOG.md) for what is queued.
 
 Preprocessing and the core classifiers are Tier 1; grateful-patient featurization and `philanthropy.ingest` are Tier 2 (Beta); `FinancialForecastModel` and `philanthropy.experimental.*` are Tier 3 (Experimental) and carry no API guarantees. From `1.0.0`, Tier 1 becomes semver-protected: breaking one requires a major release preceded by a full published minor of `DeprecationWarning`. Per-symbol tiers are in the [API reference](docs/reference/index.md).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,13 +14,15 @@ at least one minor release and emits a `DeprecationWarning` pointing at its
 replacement before removal. Supported versions are listed in
 [SECURITY.md](SECURITY.md).
 
-Nothing is deprecated at 0.7.0. When you next need to deprecate something,
-reintroduce the one mechanism 0.6.0 used: a `deprecated_alias(new_name,
-removed_in=...)` decorator in `philanthropy/utils/_deprecation.py` for a renamed
-method, and an inline `warnings.warn(..., DeprecationWarning)` in `fit`/`split`
-for a parameter that no longer does anything, plus a `tests/test_deprecations.py`
-whose registry meta-test fails when a shim ships untested. Per-symbol stability
-tiers live in [docs/reference/index.md](docs/reference/index.md).
+0.7.0 ships one deprecation, `WealthScreeningImputerKNN(group_col_idx=...)`,
+removed in 0.8.0, via an inline `warnings.warn(..., DeprecationWarning)` in
+`fit` for a parameter that no longer does anything. `tests/test_deprecations.py`
+is back for it, with a registry meta-test that fails when a shim ships
+untested. `philanthropy/utils/_deprecation.py`, 0.6.0's
+`deprecated_alias(new_name, removed_in=...)` decorator for a renamed method,
+was removed at 0.7.0 alongside the shims it policed; reintroduce it the next
+time a renamed method needs one. Per-symbol stability tiers live in
+[docs/reference/index.md](docs/reference/index.md).
 
 ## RELEASE CHECKLIST
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ cannot `pip install`, that is a bug, please report it.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.6.x   | :white_check_mark: |
-| < 0.6   | :x:                |
+| 0.7.x   | :white_check_mark: |
+| < 0.7   | :x:                |
 
 ## Loading models (trust boundary)
 

--- a/docs/explanation/benchmarks.md
+++ b/docs/explanation/benchmarks.md
@@ -231,6 +231,9 @@ These numbers, unlike the ones above, are on real donor data. They still
 establish a mechanism and its magnitude on one real file, not a value to
 quote for your program.
 
+The script's output and environment lock are archived separately on Zenodo:
+[10.5281/zenodo.22050649](https://doi.org/10.5281/zenodo.22050649).
+
 ## Validating on your own data
 
 1. Assemble a labelled historical dataset (features + a binary outcome you can

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,9 +122,9 @@ PhilanthroPy is a production-ready Python library that slots directly into `skle
 
 Get up and running in seconds:
 
-!!! info "Current release: 0.6.0"
-    `pip install philanthropy` gives you **0.6.0**. These docs are built from
-    `main`, which also carries the merged-but-unreleased 0.7.0 and 1.0.0 work.
+!!! info "Current release: 0.7.0"
+    `pip install philanthropy` gives you **0.7.0**. These docs are built from
+    `main`, which also carries the merged-but-unreleased 1.0.0 work.
     See [Deprecations](reference/index.md#deprecations) for the handful of
     differences that affect you today.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -86,20 +86,42 @@ Every domain method returns a number on its own scale. None of them are calibrat
 ## Deprecations
 
 !!! info "This page is built from `main`, which is ahead of the release"
-    `pip install philanthropy` currently gives you **0.6.0**. The tier tables
+    `pip install philanthropy` currently gives you **0.7.0**. The tier tables
     above describe the API as it stands on `main`; the deprecations below are
     live in the version you actually have installed.
 
-### Live in 0.6.0, removed in 0.7.0
+### Removed in 0.7.0
 
-These still work and emit `DeprecationWarning`. Migrate before upgrading.
+If you are upgrading from 0.6.0, these are gone, each after one full published
+minor of `DeprecationWarning`:
 
-| Deprecated | Use instead |
+| Removed | Use instead |
 |---|---|
 | `AskAmountRecommender.predict_ask_array` | `ask_ladder` |
 | `ShareOfWalletRegressor.predict_capacity_ratio` | `capacity_ratio` |
 | `MovesManagementClassifier.predict_action_priority` | `action_priority` |
 | `PlannedGivingIntentScorer.predict_bequest_intent_score` | `predict_intent_score` |
+
+The `predict_` prefix is reserved for methods that take `X` alone and return one
+value per row. The first three returned a `(n, 3)` dollar matrix, required a
+second argument, and returned a dict respectively.
+
+Three constructor parameters that had no effect are gone too; passing any of
+them is now a `TypeError`: `LapsePredictor(lapse_window_years=...)`,
+`PropensityScorer(estimator=...)`, `FiscalYearGroupedSplitter(fiscal_year_start=...)`.
+
+`donor_acquisition_cost`, `cost_per_dollar_raised` and `fundraising_roi` are now
+**keyword-only**: they do not share an argument order, so a positional call was
+silently accepted and returned a plausible wrong number. Write them with
+keywords and the upgrade is a no-op.
+
+Four accidental second import paths moved behind underscores, so 1.0 does not
+freeze them: `metrics.scoring` → `metrics._scoring`,
+`preprocessing.transformers` → `preprocessing._transformers`,
+`models.propensity` → `models._propensity_baseline`, `utils.testing` →
+`utils._testing`. Every public symbol they export is unchanged; import from the
+subpackage (`from philanthropy.metrics import ...`), as the documented examples
+always have, and nothing breaks.
 
 ### Live in 0.7.0, removed in 0.8.0
 
@@ -119,29 +141,3 @@ barely registers.
 
 If you need per-group behaviour, split the frame by group and fit one imputer per
 part. That is explicit, and it costs nothing that the parameter was buying.
-
-The `predict_` prefix is reserved for methods that take `X` alone and return one
-value per row. The first three returned a `(n, 3)` dollar matrix, required a
-second argument, and returned a dict respectively.
-
-Three constructor parameters have no effect and warn when set to a non-default
-value: `LapsePredictor(lapse_window_years=...)`,
-`PropensityScorer(estimator=...)`,
-`FiscalYearGroupedSplitter(fiscal_year_start=...)`. All three are removed in
-0.7.0.
-
-### Already merged for 0.7.0
-
-Beyond removing everything above, 0.7.0 makes `donor_acquisition_cost`,
-`cost_per_dollar_raised` and `fundraising_roi` **keyword-only**: they do not
-share an argument order, so a positional call was silently accepted and returned
-a plausible wrong number. Write them with keywords today and the upgrade is a
-no-op.
-
-It also moves four accidental second import paths behind underscores, so 1.0
-does not freeze them: `metrics.scoring` → `metrics._scoring`,
-`preprocessing.transformers` → `preprocessing._transformers`,
-`models.propensity` → `models._propensity_baseline`, `utils.testing` →
-`utils._testing`. Every public symbol they export is unchanged; import from the
-subpackage (`from philanthropy.metrics import ...`), as the documented examples
-always have, and nothing breaks.

--- a/paper.bib
+++ b/paper.bib
@@ -175,3 +175,14 @@
   note         = {UCI KDD Archive. Direct-mail donor learning set used for the
     real-data leakage replication in \texttt{scripts/real\_data\_leakage\_experiment.py}}
 }
+
+@misc{kddcup1998replicationzenodo,
+  title        = {{PhilanthroPy}: real-data replication of the temporal-leakage experiment ({KDD Cup 1998})},
+  author       = {Lalakiya, Shivam Ashokbhai},
+  year         = {2026},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.22050649},
+  howpublished = {\url{https://doi.org/10.5281/zenodo.22050649}},
+  note         = {Archived reproducible materials: the experiment script,
+    its unedited output, and an environment lock}
+}

--- a/paper.md
+++ b/paper.md
@@ -169,11 +169,13 @@ PhilanthroPy is not yet in documented use at a third-party institution, and
 this paper does not claim otherwise. What exists today is the software, a
 reproducible leakage experiment whose result is reported above and now
 replicated on real donor data (KDD Cup 1998 [@kddcup1998]) rather than only on
-a synthetic generator, a benchmark page that states its own synthetic-data
-limitations and the Bayes-optimal ceiling of its generator, an archived
-release on Zenodo, and eleven merged pull requests from four contributors
-external to the project. The author's prior conference paper on predictive
-donor analytics [@lalakiya2025] is related work by the same author on
+a synthetic generator, with its script output and environment archived
+separately on Zenodo with its own DOI [@kddcup1998replicationzenodo], a
+benchmark page that states its own synthetic-data limitations and the
+Bayes-optimal ceiling of its generator, an archived release on Zenodo, and
+eleven merged pull requests from four contributors external to the project.
+The author's prior conference paper on predictive donor analytics
+[@lalakiya2025] is related work by the same author on
 different data, not an independent evaluation of this software.
 
 The intended research audience is twofold: advancement-analytics practitioners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "philanthropy"
-version = "0.6.0"
+version = "0.7.0"
 description = "scikit-learn-native predictive analytics for nonprofit and academic-medical-center fundraising: donor propensity, lapse, planned giving, wealth screening, and revenue forecasting."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -88,7 +88,7 @@ UniSchema = "https://github.com/PhilanthroPy-Project/UniSchema"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["philanthropy*"]
+include = ["philanthropy", "philanthropy.*"]
 
 [tool.setuptools.package-data]
 "philanthropy" = ["py.typed"]


### PR DESCRIPTION
## Summary
- Closes `## [Unreleased]` in `CHANGELOG.md` into a dated `## [0.7.0] - 2026-08-21` section, merged with the pre-staged removal-release entries already there. Fixed two bullets that became contradictory once merged (one claimed `tests/test_deprecations.py` was removed, a later one said it came back for a new shim; one claimed "nothing is deprecated at 0.7.0", which the merge made false).
- Bumps `pyproject.toml` to `0.7.0`.
- Updates `CITATION.cff` (`version`, `date-released`, and the stale DOI comment), the `SECURITY.md` supported-versions table, and rewrites `docs/reference/index.md`'s Deprecations section (removed-in-0.7.0 vs. still-live-in-0.7.0, instead of the old 0.6.0-vs-0.7.0 framing).
- Fixes `RELEASING.md`'s own "nothing is deprecated at 0.7.0" line, which was already false against `main` before this PR (the `group_col_idx` deprecation landed after that sentence was written).
- Updates `README.md` and `docs/index.md`'s "current release" callouts from 0.6.0 to 0.7.0.
- **Tightens `pyproject.toml`'s package-discovery glob** from `"philanthropy*"` to `"philanthropy", "philanthropy.*"`. Running RELEASING.md's own packaging check (`python -m build`) locally showed the wildcard also matches the untracked `philanthropy-append/` prototype directory by prefix and puts it in the wheel. Not tracked by git, so the real CI build was never affected, but the pattern was one accidental `git add` away from shipping it. Verified with a clean rebuild afterward: `philanthropy-append/` excluded, full `philanthropy/` package intact, `twine check --strict` passes.

This is issue #125, steps 2-5 of `RELEASING.md`'s checklist. **Not included**, per the issue's own "maintainer only" / "effectively irreversible" callout: tagging `v0.7.0`, publishing to PyPI, and the Zenodo deposit (steps 6-8). Those need PyPI/GitHub-release/Zenodo actions I can't and shouldn't take myself.

## Test plan
- [x] `make ci`: 1862 passed, 0 failed, coverage 96.80%
- [x] `make riskcov`: green
- [x] `pytest tests/test_public_api_contract.py -q`: 81 passed
- [x] `mkdocs build --strict`: clean
- [x] `python -m build && python -m twine check --strict dist/*`: both PASSED, `philanthropy-append/` confirmed excluded from the rebuilt wheel
- [x] No test hardcodes the old `"0.6.0"` version string