### PR TITLE
docs: the two-rank floor more than doubles, and say by how much

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   - Three one-rank conformity scores via `score=`: `"absolute"`,
     `"difficulty"` (residual over a difficulty estimate) and `"log"` (residual
     on `log1p` dollars, inverted). Equal-tailed two-rank intervals are
-    deliberately not offered: two order statistics at `alpha / 2` double the
+    deliberately not offered: two order statistics at `alpha / 2` more than double the
     floor to 39 rows and buy nothing the one-rank forms do not.
   - Intersects the interval with `[lower_bound, inf)`, default `0.0`. A gift
     cannot be negative, so coverage is bit-identical and width strictly falls.

--- a/philanthropy/models/_conformal_interval.py
+++ b/philanthropy/models/_conformal_interval.py
@@ -244,8 +244,10 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
             the domain.
 
         Equal-tailed two-rank intervals are deliberately absent: two order
-        statistics at ``alpha / 2`` double the floor (39 rows at the 95 % level,
-        against 19) and buy nothing these three do not.
+        statistics at ``alpha / 2`` more than double the floor (39 rows at the
+        95 % level against 19) and buy nothing these three do not. The ratio is
+        ``(2 - alpha) / (1 - alpha)``, which is strictly above two at every level
+        and reaches two only as ``alpha`` goes to zero.
     difficulty_estimator : object or callable, default=None
         Required when ``score="difficulty"``. Either an object with ``predict``
         or a callable, mapping ``X`` to strictly positive scale estimates. Fit it

--- a/tests/test_conformal_interval.py
+++ b/tests/test_conformal_interval.py
@@ -560,7 +560,8 @@ def test_log_score_refuses_negative_dollars():
 
 
 def test_equal_tailed_two_rank_is_not_on_offer():
-    # Two order statistics at alpha / 2 double the floor for no gain the
+    # Two order statistics at alpha / 2 MORE than double the floor -- the ratio is
+    # (2 - alpha)/(1 - alpha), above two at every level -- for no gain the
     # one-rank scores do not already deliver. Failing input: score="quantile"
     # or any other value, which must raise rather than fall through.
     X, y = _panel(n=300)


### PR DESCRIPTION
Follow-up to #140. Documentation only, no behaviour change.

## What

Three places said two order statistics at `alpha / 2` "double the floor":

- `philanthropy/models/_conformal_interval.py:247` (the `score` docstring)
- `tests/test_conformal_interval.py:563` (comment on `test_equal_tailed_two_rank_is_not_on_offer`)
- `CHANGELOG.md:28`

They more than double it. The ratio is `(2 - alpha) / (1 - alpha)`, strictly above two for every
`alpha` in (0, 1) and reaching two only in the limit:

| level | one-rank floor | two-rank floor | ratio | `(2-a)/(1-a)` |
|---|---|---|---|---|
| 0.90 | 9 | 19 | 2.1111 | 2.1111 |
| 0.95 | 19 | 39 | 2.0526 | 2.0526 |
| 0.99 | 99 | 199 | 2.0101 | 2.0101 |

## Why it is worth three lines

Calling it a factor of two understates the one-rank floor's advantage at every level a caller
would actually request, and the floor is the thing that decides whether `GiftIntervalCalibrator`
can serve a segment at all. #140's whole design turns on that number.

## Verification

```
python -m doctest philanthropy/models/_conformal_interval.py philanthropy/metrics/_conformal.py
12 tests in 14 items, 12 passed
```

Both edited files parse; the test-file change is a comment.