### PR TITLE
feat: rename sow_score to capacity_utilisation_ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   information; the ratio is what separates the two.
 
 ### Changed
+- `ShareOfWalletScorer` output column 0 is renamed `sow_score` →
+  `capacity_utilisation_ratio`. The formula was always capacity ÷ clipped
+  modelled wealth: utilisation of estimated capacity, with no term for giving to
+  *your* institution, so the old name claimed a share-of-wallet quantity the
+  score cannot express (the class docstring has warned about exactly this since
+  it shipped). Values, column order, and `capacity_tier` are unchanged; code
+  reading column 0 positionally needs nothing. Code spelling the name gets one
+  published minor of grace via `get_legacy_feature_names_out()`, which returns
+  the old `["sow_score", "capacity_tier"]` under a `DeprecationWarning` and is
+  removed in 0.9.0; the shim is registered in `tests/test_deprecations.py`.
+  Closes #109.
 - `predict_<thing>_interval` joins `_score` and `_forecast` as an accepted
   domain-method suffix in the public-API naming contract
   (`tests/test_public_api_contract.py`, `AGENTS.md`).

--- a/docs/explanation/capacity_and_loyalty.md
+++ b/docs/explanation/capacity_and_loyalty.md
@@ -18,9 +18,9 @@ This ratio is rooted in industry standards and aligns with benchmarks establishe
 
 ### Capacity Tiers
 
-Categories are easier to act on than raw numbers, so `ShareOfWalletScorer.transform` emits a second column, `capacity_tier`, alongside `sow_score`. It is a numeric encoding; `get_tier_labels(X)` returns the strings.
+Categories are easier to act on than raw numbers, so `ShareOfWalletScorer.transform` emits a second column, `capacity_tier`, alongside `capacity_utilisation_ratio`. It is a numeric encoding; `get_tier_labels(X)` returns the strings.
 
-| `sow_score` | `capacity_tier` | Label | Recommended action |
+| `capacity_utilisation_ratio` | `capacity_tier` | Label | Recommended action |
 |---|---|---|---|
 | ≥ 0.75 | 2 | **Principal** | Schedule a personal visit with the campaign chair. |
 | 0.40 – 0.75 | 1 | **Major** | Assign a major gift officer. |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -76,7 +76,7 @@ Every domain method returns a number on its own scale. None of them are calibrat
 | `LapsePredictor.predict_lapse_score` | `(n,)` float | 0–100, higher = more likely to lapse |
 | `PlannedGivingIntentScorer.predict_intent_score` | `(n,)` float | 0–100 |
 | `UpliftTLearner.predict_uplift_score` | `(n,)` float | **−1 to 1**, negative means the appeal suppresses giving |
-| `ShareOfWalletScorer.transform` | `(n, 2)` float | `sow_score` 0–1; `capacity_tier` in {0, 1, 2} |
+| `ShareOfWalletScorer.transform` | `(n, 2)` float | `capacity_utilisation_ratio` 0–1; `capacity_tier` in {0, 1, 2} |
 | `ShareOfWalletRegressor.capacity_ratio` | `(n,)` float | Unbounded ratio ≥ 0 (capacity ÷ historical giving) |
 | `DischargeToSolicitationWindowTransformer.transform` | `(n, 2)` float | `in_solicitation_window` in {0, 1}; `window_position_score` 0–1 |
 | `GratefulPatientFeaturizer.transform` | `(n, 4)` float | Unbounded counts and weighted sums, all ≥ 0 |
@@ -143,3 +143,20 @@ barely registers.
 
 If you need per-group behaviour, split the frame by group and fit one imputer per
 part. That is explicit, and it costs nothing that the parameter was buying.
+
+### Live on `main` (0.8.0), removed in 0.9.0
+
+| Deprecated | Use instead |
+|---|---|
+| `ShareOfWalletScorer` output name `sow_score` | `capacity_utilisation_ratio` |
+
+`ShareOfWalletScorer.transform` column 0 is now named
+`capacity_utilisation_ratio` in `get_feature_names_out()`: the formula is
+capacity ÷ clipped modelled wealth, which is capacity utilisation. It was never
+share of wallet; the docstring has said so since the class shipped, and the old
+name claimed a quantity the formula does not compute. The values, the column
+order, and the `capacity_tier` encoding are unchanged, so code that reads the
+column positionally needs nothing. Code that spells the name can call
+`get_legacy_feature_names_out()` for one published minor: it returns the old
+`["sow_score", "capacity_tier"]` spelling under a `DeprecationWarning` and is
+removed in 0.9.0.

--- a/philanthropy/preprocessing/_share_of_wallet.py
+++ b/philanthropy/preprocessing/_share_of_wallet.py
@@ -432,7 +432,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
     capacity scoring pipeline.  It consumes a numeric feature matrix and
     produces two outputs per row:
 
-    ``sow_score`` (float64, [0, 1])
+    ``capacity_utilisation_ratio`` (float64, [0, 1])
         Capacity utilisation:
 
             score = estimated_capacity / (clipped_modelled_wealth + epsilon)
@@ -450,9 +450,10 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
            institutional giving in the numerator and total estimated giving in
            the denominator, and this transformer is given neither. Read it as
            "how much of this donor's modelled wealth is estimated to be
-           philanthropic capacity". The output name is kept for backward
-           compatibility and is scheduled to be renamed in the next major
-           release.
+           philanthropic capacity". Until 0.8.0 the column was named
+           ``sow_score``, which claimed a quantity the formula does not
+           compute; :meth:`get_legacy_feature_names_out` still spells it that
+           way, under a `DeprecationWarning`, until 0.9.0 removes it.
 
         The denominator is clipped at the fit-time 95th percentile, so the
         wealthiest rows share one denominator and are pushed toward the top of
@@ -588,7 +589,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         Returns
         -------
         X_out : np.ndarray of shape (n_samples, 2), dtype float64
-            Column 0: ``sow_score`` in [0, 1].
+            Column 0: ``capacity_utilisation_ratio`` in [0, 1].
             Column 1: ``capacity_tier`` (0 = Leadership, 1 = Major, 2 = Principal).
 
         Raises
@@ -639,12 +640,37 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         return np.column_stack([sow, tiers])
 
     def get_feature_names_out(self, input_features=None) -> np.ndarray:
-        """Return the share-of-wallet score and encoded tier names.
+        """Return the capacity-utilisation ratio and encoded tier names.
 
         Parameters
         ----------
         input_features : array-like of str or None, default=None
             Ignored because the scorer always emits the same two features.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str
+            ``["capacity_utilisation_ratio", "capacity_tier"]``.
+
+        Raises
+        ------
+        NotFittedError
+            If the scorer has not been fitted.
+        """
+        check_is_fitted(self)
+        return np.array(
+            ["capacity_utilisation_ratio", "capacity_tier"], dtype=object
+        )
+
+    def get_legacy_feature_names_out(self) -> np.ndarray:
+        """Return the pre-0.8.0 output names, ``sow_score`` first.
+
+        The formula behind column 0 is capacity utilisation, not share of
+        wallet, so the column is now named ``capacity_utilisation_ratio``
+        (see :meth:`get_feature_names_out`). This method keeps the old
+        spelling reachable for one published minor release: it emits a
+        `DeprecationWarning` and returns ``["sow_score", "capacity_tier"]``.
+        Removed in 0.9.0.
 
         Returns
         -------
@@ -657,6 +683,15 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
             If the scorer has not been fitted.
         """
         check_is_fitted(self)
+        warnings.warn(
+            "ShareOfWalletScorer output name 'sow_score' is deprecated since "
+            "0.8.0 and will be removed in 0.9.0; the column measures capacity "
+            "utilisation, not share of wallet. Use "
+            "get_feature_names_out(), which reports "
+            "'capacity_utilisation_ratio' first.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return np.array(["sow_score", "capacity_tier"], dtype=object)
 
     def get_tier_labels(self, X) -> np.ndarray:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from philanthropy import preprocessing, utils
-from philanthropy.preprocessing import WealthScreeningImputerKNN
+from philanthropy.preprocessing import ShareOfWalletScorer, WealthScreeningImputerKNN
 
 # (id, removed_in, callable that should emit exactly one DeprecationWarning)
 DEPRECATIONS = [
@@ -23,6 +23,13 @@ DEPRECATIONS = [
         lambda: WealthScreeningImputerKNN(
             strategy="knn", n_neighbors=3, add_indicator=False, group_col_idx=1
         ).fit(_two_group_X()),
+    ),
+    (
+        "ShareOfWalletScorer.get_legacy_feature_names_out",
+        "0.9.0",
+        lambda: ShareOfWalletScorer()
+        .fit(_two_group_X())
+        .get_legacy_feature_names_out(),
     ),
     (
         "utils.make_donor_dataset",

--- a/tests/test_share_of_wallet.py
+++ b/tests/test_share_of_wallet.py
@@ -372,3 +372,33 @@ def test_share_of_wallet_scorer_tier_labels_are_exact():
                                             dtype=object)
     )
     np.testing.assert_array_equal(scorer.transform(X)[:, 1], [1.0, 0.0, 0.0])
+
+
+def test_capacity_utilisation_ratio_is_the_new_column_name():
+    # The formula is capacity / clipped modelled wealth: capacity utilisation,
+    # not share of wallet. Column 0 is renamed accordingly; the values and the
+    # column order are unchanged.
+    # Wealth sums are equal, so the fit-time p95 clip cannot bind.
+    X = np.array([[100.0, 100.0], [50.0, 150.0]])
+    scorer = ShareOfWalletScorer(capacity_col_idx=0).fit(X)
+    assert list(scorer.get_feature_names_out()) == [
+        "capacity_utilisation_ratio",
+        "capacity_tier",
+    ]
+    out = scorer.transform(X)
+    np.testing.assert_allclose(out[:, 0], [100.0 / 201.0, 50.0 / 201.0])
+
+
+def test_sow_score_still_works_and_warns():
+    # One published minor of grace: the old spelling stays reachable and
+    # describes the same column, under a DeprecationWarning saying when it
+    # goes.
+    X = np.array([[100.0, 100.0], [50.0, 150.0]])
+    scorer = ShareOfWalletScorer(capacity_col_idx=0).fit(X)
+    with pytest.warns(DeprecationWarning, match="removed in 0.9.0"):
+        legacy = scorer.get_legacy_feature_names_out()
+    assert list(legacy) == ["sow_score", "capacity_tier"]
+    # The rename is a spelling change only: column 0 holds the same ratio.
+    np.testing.assert_allclose(
+        scorer.transform(X)[:, 0], [100.0 / 201.0, 50.0 / 201.0]
+    )


### PR DESCRIPTION
## Summary
- Rename `ShareOfWalletScorer` column 0 from `sow_score` to `capacity_utilisation_ratio` in `get_feature_names_out()`.
- Keep a one-minor compatibility path with `get_legacy_feature_names_out()`, which returns `["sow_score", "capacity_tier"]` under a `DeprecationWarning` and is registered in `tests/test_deprecations.py`.
- Update the reference docs, capacity and loyalty explanation, and changelog. `CONTRIBUTORS.md` already lists `@slegarraga`, so I did not duplicate the entry.

Closes #109.

## Verification
- `env -u PYTHONPATH PATH="/tmp/oss-replies/philanthropy/.venv/bin:$PATH" make ci`
  - flake8 passed
  - mypy passed
  - doctests: 34 passed
  - collection: 1931 tests collected, 0 errors
  - tests with coverage: 1906 passed, 25 skipped, coverage 97.05 percent, floor 92.0 percent
- `env -u PYTHONPATH PATH="/tmp/oss-replies/philanthropy/.venv/bin:$PATH" make riskcov`
  - exit 0, risk-tier total coverage 96 percent
- `git diff --check`
