### PR TITLE
test: cover FinancialForecastModel linear-only predict and short-history AR padding

### DIFF
--- a/tests/test_forecast_model.py
+++ b/tests/test_forecast_model.py
@@ -91,6 +91,22 @@ def test_hybrid_uses_nonlinear_component(revenue_Xy):
     assert not np.allclose(linear_only, hybrid)
 
 
+def test_predict_without_nonlinear_model_uses_linear_only(revenue_Xy):
+    """A single training sample leaves the residual network unfitted
+    (`nonlinear_model_ is None`): `predict` must return the bare linear
+    prediction instead of adding any residual term."""
+    X, y = revenue_Xy
+    model = FinancialForecastModel(random_state=0).fit(X[:1], y[:1])
+    assert model.nonlinear_model_ is None
+    # NaN-free probe, so imputation is the identity and comparing against
+    # `linear_model_.predict` directly is exact.
+    X_probe = np.asarray(X[:3], dtype=float)
+    np.testing.assert_allclose(
+        model.predict(X_probe),
+        model.linear_model_.predict(X_probe),
+    )
+
+
 # ---------------------------------------------------------------------------
 # predict_revenue_forecast
 # ---------------------------------------------------------------------------
@@ -109,6 +125,32 @@ def test_forecast_flat_when_ar_order_zero(revenue_Xy):
     model = FinancialForecastModel(ar_order=0, random_state=0).fit(X, y)
     forecast = model.predict_revenue_forecast(X, horizon=5)
     assert np.allclose(forecast, forecast[0])
+
+
+def test_predict_revenue_forecast_pads_short_history_with_training_mean(revenue_Xy):
+    """Context with fewer rows than `ar_order` must not crash: the seed window
+    is padded to length p with the frozen training mean before the
+    autoregressive roll-forward starts."""
+    X, y = revenue_Xy
+    p = 5
+    horizon = 4
+    model = FinancialForecastModel(ar_order=p, random_state=0).fit(X, y)
+
+    short = model.predict_revenue_forecast(X[:2], horizon=horizon)
+    assert short.shape == (horizon,)
+    assert np.isfinite(short).all()
+
+    # Reproduce the documented roll-forward by hand from the frozen fitted
+    # statistics: most-recent-first hybrid predictions, padded out to p lags
+    # with y_mean_. This pins the pad value, not just finiteness.
+    history = model.predict(X[:2])
+    window = list(history[::-1]) + [model.y_mean_] * (p - history.size)
+    expected = []
+    for _ in range(horizon):
+        nxt = model.ar_intercept_ + float(np.dot(model.ar_coef_, window))
+        expected.append(nxt)
+        window = [nxt] + window[:-1]
+    np.testing.assert_allclose(short, np.asarray(expected))
 
 
 @pytest.mark.parametrize("bad", [0, -1, 2.5, True, "3"])


### PR DESCRIPTION
Closes #59. Test-only, no source change.

## What

Two named tests in `tests/test_forecast_model.py`, exactly as specced:

1. `test_predict_without_nonlinear_model_uses_linear_only`: fits on a single training sample, which leaves the residual network unfitted (`nonlinear_model_ is None`), then asserts `predict(X)` matches `linear_model_.predict` on the same NaN-free input exactly. The probe is NaN-free on purpose, so imputation is the identity and the comparison against the linear sub-model is direct.
2. `test_predict_revenue_forecast_pads_short_history_with_training_mean`: fits with `ar_order=5`, calls `predict_revenue_forecast` with 2 context rows (fewer than `p`), asserts a finite `(horizon,)` array, and then reproduces the documented roll-forward by hand from the frozen fitted statistics (`predict` history reversed most-recent-first, padded to `p` with `y_mean_`), so the test pins the pad value rather than just finiteness.

## Evidence

Coverage of `philanthropy/models/_forecast.py` from this file, before and after (branch coverage):

```
before: 90 stmts, Miss 1, BrPart 2, 97%, Missing: 288->290, 341
after:  90 stmts, Miss 0, BrPart 0, 100%
```

`341` is the `window = list(history[::-1]) + [self.y_mean_] * (p - history.size)` padding line and `288->290` the `if self.nonlinear_model_ is not None` guard, the two branches named in the issue. Unrelated partial branches elsewhere in the module: none left in this file, nothing else touched.

## Local verification

- `python -m pytest tests/ -q`: 1910 passed, 25 skipped.
- `python -m pytest tests/test_forecast_model.py -q`: 78 passed, 1 skipped.
- `flake8 tests/test_forecast_model.py`: clean.

Test-only PR, so no CHANGELOG entry per the precedent noted in #139.
