### PR TITLE
test: cover DataFrame feature names in MovesManagementClassifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   NaN with a `UserWarning` naming them, and a column where nothing parses
   (all-complex included) still raises `could not parse` per the documented
   contract. Closes #129.
+  - Added regression coverage ensuring `MovesManagementClassifier.fit` preserves
+  DataFrame column names in `feature_names_in_`. Closes #54.
 ### Added
 - **`models.GiftIntervalCalibrator`**: distribution-free intervals on a dollar
   amount. Wraps an already-fitted regressor (`AskAmountRecommender`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   CONTRIBUTORS.md. Implemented as `scripts/check_credit.sh`, wired into
   `ci.yml` on `pull_request` events only; failures surface as inline
   `::error::` annotations on the Files tab. Closes #113.
+- Regression coverage ensuring `MovesManagementClassifier.fit` preserves
+  DataFrame column names in `feature_names_in_`. Closes #54.
 ### Fixed
 - `CRMCleaner.transform` no longer silently corrupts complex amounts into
   wrong finite floats: cells holding actual `complex` values are masked to
   NaN with a `UserWarning` naming them, and a column where nothing parses
   (all-complex included) still raises `could not parse` per the documented
   contract. Closes #129.
-  - Added regression coverage ensuring `MovesManagementClassifier.fit` preserves
-  DataFrame column names in `feature_names_in_`. Closes #54.
 ### Added
 - **`models.GiftIntervalCalibrator`**: distribution-free intervals on a dollar
   amount. Wraps an already-fitted regressor (`AskAmountRecommender`,

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,8 +34,9 @@ contribution. Code, docs, tests, and review all count.
   ([#64](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/64),
   [#65](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/65),
   [#66](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/66)).
-  - [@stoppo22](https://github.com/stoppo22): added DataFrame feature-name
-  coverage for `MovesManagementClassifier.fit`.
+- [@stoppo22](https://github.com/stoppo22): added DataFrame feature-name
+  coverage for `MovesManagementClassifier.fit`
+  ([#146](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/146)).
 
 ## Getting listed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,8 @@ contribution. Code, docs, tests, and review all count.
   ([#64](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/64),
   [#65](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/65),
   [#66](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/66)).
+  - [@stoppo22](https://github.com/stoppo22): added DataFrame feature-name
+  coverage for `MovesManagementClassifier.fit`.
 
 ## Getting listed
 

--- a/tests/test_moves.py
+++ b/tests/test_moves.py
@@ -5,6 +5,7 @@ a metric as the goal rather than the behaviour under test.
 """
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from philanthropy.models import MovesManagementClassifier
@@ -55,3 +56,21 @@ def test_action_priority_summary_counts_every_donor(stage_Xy):
     summary = clf.action_priority(X)["portfolio_summary"]
     assert sum(summary.values()) == 30
     assert set(summary) <= set(_STAGES)
+
+
+def test_fit_with_dataframe_sets_feature_names_in():
+    X = pd.DataFrame(
+        np.random.default_rng(0).random((30, 5)),
+        columns=["age", "income", "donations", "engagement", "years_active"],
+    )
+    y = np.asarray(_STAGES * 10)
+
+    clf = MovesManagementClassifier(max_iter=10, random_state=0).fit(X, y)
+
+    np.testing.assert_array_equal(
+        clf.feature_names_in_,
+        np.array(
+            ["age", "income", "donations", "engagement", "years_active"],
+            dtype=object,
+        ),
+    )


### PR DESCRIPTION
## What & why

Adds regression coverage for `MovesManagementClassifier.fit` when the feature matrix is provided as a `pandas.DataFrame`.

The new test verifies that fitting on named DataFrame columns correctly preserves those names in `feature_names_in_`.

Closes #54.

Local CI completed successfully:

```bash
uv run make ci
```

Result:
- 1909 passed
- 25 skipped
- 97.09% total coverage

## Checklist
- [x] `make ci` passes locally (lint → collection → tests → coverage ≥ 92%)
- [ ] New/changed public API has docstrings and is exported in the subpackage `__init__.py`
- [x] Tests added or updated
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Added yourself to `CONTRIBUTORS.md` (skip if you would rather not be listed)