### PR TITLE
test: cover planned giving single-class intent score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   flips between the three is a ranking of the tail), median width, and
   `width_ratio` = median width over median target. A valid interval can carry no
   information; the ratio is what separates the two.
+- Test coverage for `PlannedGivingIntentScorer.predict_intent_score`: the
+  single-class `predict_proba` fallback path that returns an all-zero score.
+  (#56)
 
 ### Changed
 - `ShareOfWalletScorer` output column 0 is renamed `sow_score` →

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,10 @@ contribution. Code, docs, tests, and review all count.
 - [@stoppo22](https://github.com/stoppo22): added DataFrame feature-name
   coverage for `MovesManagementClassifier.fit`
   ([#146](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/146)).
+- [@Mohd-Hamza-Khan](https://github.com/Mohd-Hamza-Khan): added the missing
+  single-class fallback coverage for
+  `PlannedGivingIntentScorer.predict_intent_score`
+  ([#149](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/149)).
 
 ## Getting listed
 

--- a/tests/test_planned_giving.py
+++ b/tests/test_planned_giving.py
@@ -13,7 +13,8 @@ from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 
 from philanthropy.preprocessing import PlannedGivingSignalTransformer
-
+from philanthropy.models import PlannedGivingIntentScorer
+from unittest.mock import patch
 
 # ---------------------------------------------------------------------------
 # Shared helper
@@ -210,3 +211,61 @@ class TestPlannedGivingSignalTransformer:
         assert result[0, 3] == pytest.approx(2.0), (
             "composite_score must ignore sentinel -1.0 (treat as 0 in max)"
         )
+
+
+class TestPlannedGivingIntentScorer:
+
+    def test_predict_intent_score_single_class_returns_zeros(self):
+        """Single-class probability output must return all zeros."""
+        rng = np.random.default_rng(0)
+        X = rng.random((20, 4))
+
+        # Fit with multi-class data because CalibratedClassifierCV
+        # requires at least two classes during fitting.
+        m = PlannedGivingIntentScorer(n_estimators=5, random_state=0).fit(
+            X,
+            np.array([
+                0, 0, 0, 0, 1, 1, 1, 1,
+                0, 0, 0, 0, 1, 1, 1, 1,
+                0, 0, 0, 1,
+            ]),
+        )
+
+        # Simulate predict_proba() returning one column,
+        # which triggers the single-class fallback.
+        with patch.object(
+            m,
+            "predict_proba",
+            return_value=np.zeros((20, 1)),
+        ):
+            scores = m.predict_intent_score(X)
+
+        assert scores.shape == (20,)
+        np.testing.assert_array_equal(scores, np.zeros(20))
+
+
+
+    def test_predict_intent_score_multi_class(self):
+        """Multi-class training fold must return P(class=1) * 100."""
+        rng = np.random.default_rng(0)
+        X = rng.random((20, 4))
+        y = (X[:, 0] + rng.random(20) * 0.1 > 0.5).astype(int)
+
+        m = PlannedGivingIntentScorer(n_estimators=5, random_state=0).fit(X, y)
+        scores = m.predict_intent_score(X)
+
+        assert scores.shape == (20,)
+        assert np.all(scores >= 0.0) and np.all(scores <= 100.0)
+        # Score is P(class=1) * 100, rounded to 2 dp.
+        expected = np.round(m.predict_proba(X)[:, 1] * 100.0, 2)
+        np.testing.assert_array_almost_equal(scores, expected)
+
+    def test_predict(self):
+        """Test predict method."""
+        rng = np.random.default_rng(0)
+        X = rng.random((20, 4))
+        y = (X[:, 0] + rng.random(20) * 0.1 > 0.5).astype(int)
+
+        m = PlannedGivingIntentScorer(n_estimators=5, random_state=0).fit(X, y)
+        predictions = m.predict(X)
+        assert predictions.shape == (20,)


### PR DESCRIPTION
Summary

Adds test coverage for the single-class probability fallback in PlannedGivingIntentScorer.predict_intent_score.

What changed
Added test_predict_intent_score_single_class_returns_zeros.
Simulates a single-class predict_proba() output with one probability column.
Verifies that predict_intent_score() returns a zero score for every sample.
No production code was changed.
Why

The existing single-class fallback was not covered by the test suite. This test exercises the proba.shape[1] < 2 branch and verifies that it returns zeros as expected.

Testing
python -m pytest tests/test_planned_giving.py -q
python -m pytest tests/test_planned_giving.py --cov=philanthropy.models._planned_giving --cov-report=term-missing -q
make ci
make riskcov

All checks pass.

Resolves #56