### PR TITLE
docs: link the pinned who-is-using-this Discussion from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,12 @@ Everyone who has landed a change is credited in
 Questions are welcome in
 [Discussions](https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions).
 
+**Already using PhilanthroPy?** There is no telemetry in this package and there
+never will be, so
+[Are you using PhilanthroPy?](https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions/158)
+is the only place adoption is visible. One reply is enough, and "evaluated it and
+passed" is more useful than a star.
+
 ---
 
 ## License

--- a/scripts/issue-drafts/_DISCUSSION_who_is_using_this.md
+++ b/scripts/issue-drafts/_DISCUSSION_who_is_using_this.md
@@ -1,8 +1,11 @@
 # Draft: pinned Discussion "Are you using PhilanthroPy?"
 
-Not posted. Create it under the **General** category at
-<https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions/new?category=general>,
-then pin it and link it from the README.
+**Posted 2026-09-05** under **General** as
+<https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions/158>, body verbatim
+from below, and linked from the README "Contributing" section. Pinning is a web-UI
+action; the GraphQL API exposes no `pinDiscussion` mutation.
+
+Kept here as the record of what was posted and why.
 
 Rationale: the package carries no telemetry and never will (`tests/test_no_network.py`
 enforces that), so this thread is the only adoption signal that exists. GitHub


### PR DESCRIPTION
## Why

The package carries no telemetry and never will (`tests/test_no_network.py` enforces it), which
makes the "Are you using PhilanthroPy?" Discussion the only adoption signal the project has. It had
been drafted in `scripts/issue-drafts/_DISCUSSION_who_is_using_this.md` since August and never
posted, and the README linked the Discussions *tab* rather than any thread.

Zero Discussions is also a soft spot on the JOSS collaborative-effort criterion.

## What changed

- Posted the draft verbatim as [Discussion #158](https://github.com/PhilanthroPy-Project/PhilanthroPy/discussions/158).
- README "Contributing" now links the thread itself, framed so that "evaluated it and passed" is an
  invited answer, not just "we use it".
- The draft file records that it went out and when, so it stops reading as a to-do.

## Not in this PR

Pinning. The GraphQL API has no `pinDiscussion` mutation, so that is a one-click web-UI action:
Discussion #158 → ⋯ → Pin discussion.

Refs #126