### PR TITLE
docs: give the KDD Cup 1998 replication its own page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,16 @@ anywhere in `philanthropy/`; `__version__ == importlib.metadata.version(...)`
 and `py.typed` in the wheel; every `__all__` symbol carries a tier and no Tier 1
 entry is mid-deprecation.
 
+### Documentation
+- New page **Real-Data Replication: KDD Cup 1998**
+  (`docs/explanation/real_data_replication.md`), promoted out of a section of
+  `benchmarks.md` and expanded: synthetic and real numbers side by side, the
+  panel construction from the wide promotion history, the pre-registered
+  prediction that was wrong by a factor of five, the download caveat, and the
+  Zenodo replication DOI. `benchmarks.md` keeps the headline tables and links
+  out, so the measured numbers still live in exactly one place. The README
+  gains a "Validated on real donor data" section pointing at it.
+
 ## [0.7.0] - 2026-08-21
 
 The removal release, plus everything else merged since 0.6.0. Every shim

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ philanthropy score --data prospects.csv --model model.joblib --out scored.csv
 
 Nothing in the package downloads anything on its own either. No module imports a network client without being on an explicit allowlist, nothing is fetched at import time or during `fit`/`transform`, and `tests/test_no_network.py` enforces both halves in CI: it makes every socket raise across a full train/score cycle, and it parses every module in the package and fails the build if one imports a network-capable library off that allowlist. The allowlist currently names exactly one module: `philanthropy.datasets.fetch_kdd98_donors`, an opt-in function you call by name to fetch a public research dataset (KDD Cup 1998) to a local cache for validating the library against real donor data. It still never transmits any of *your* data; the only thing it fetches is a public file, once, and it is never called automatically. See **[Compliance considerations](docs/explanation/compliance_considerations.md)** and the **[security review Q&A](docs/explanation/security_review_answers.md)** for the questions an institutional review will ask.
 
+### Validated on real donor data
+
+The leakage-safety design was tested on [KDD Cup 1998](https://kdd.ics.uci.edu/databases/kddcup98/kddcup98.html), a real file of 95,412 donors with a 24-mailing giving history. Building features from the whole export instead of as of each decision point inflated walk-forward ROC-AUC by **+0.376** (0.482 → 0.858), roughly three times the effect on synthetic data, and no choice of splitter recovers any of it. That is the failure mode this library is built to prevent.
+
+The script had a prediction written into it before it ran, that real leakage would be *smaller*. It was wrong by about a factor of five, and it is reported that way. Script, output, and environment lock are archived at [doi:10.5281/zenodo.22050649](https://doi.org/10.5281/zenodo.22050649). Walkthrough: **[Real-data replication](docs/explanation/real_data_replication.md)**.
+
 ---
 
 ## From your CRM to scores

--- a/docs/explanation/benchmarks.md
+++ b/docs/explanation/benchmarks.md
@@ -187,18 +187,7 @@ The two experiments above were re-run, unchanged in structure, on a real donor
 file: [KDD Cup 1998](https://kdd.ics.uci.edu/databases/kddcup98/kddcup98.html),
 95,412 donors with a 24-mailing direct-mail history, reshaped into a
 22-period donor-period panel (`philanthropy.datasets.fetch_kdd98_donors`).
-Label: did the donor give at the following mailing; the final period's label
-is the dataset's own held-out target. Five seeds, mean with min-max.
-
-```bash
-python scripts/real_data_leakage_experiment.py
-```
-
-**Prediction, recorded in the script before it was run:** real leakage would
-be *smaller* than the synthetic figures below, because real giving habits
-persist without the synthetic generator's manufactured drift working against
-them. **That prediction was wrong**, in the direction that strengthens this
-library's argument rather than weakening it:
+Five seeds, mean ROC-AUC.
 
 | Evaluation | ROC-AUC | Error vs the true future |
 |---|---:|---:|
@@ -213,29 +202,14 @@ library's argument rather than weakening it:
 | | **+0.376 AUC of pure inflation** |
 
 Whole-history feature construction inflates real-data ROC-AUC by **+0.376
-AUC**, roughly three times the synthetic **+0.126**. A real donor's lifetime
-total repeats identically across all 22 of their period-rows, which is a
-stronger, more identity-revealing signal for a leaky feature to exploit than
-the synthetic panel's softer persistence. Splitter choice also matters more
-here than in the synthetic run: random `StratifiedKFold` overstates the true
-future by **+0.107 AUC**, an order of magnitude past the synthetic 0.014-0.030,
-reversing the direction the synthetic run found (there, random split *understated*
-the future).
+AUC**, roughly three times the synthetic **+0.126** above. The script's
+pre-registered prediction was that real leakage would be *smaller*; it was
+wrong by a factor of about five, and that is reported rather than re-run.
 
-One more honest discrepancy, reported rather than smoothed: walk-forward CV
-(0.482) undershoots the true-future baseline (0.541) here, where in the
-synthetic run it slightly overshot. Real promotion response rates swing
-sharply by campaign type (8%-22% across the historical mailings) rather than
-drifting smoothly the way the synthetic generator's drift term does, so the
-three most-recent periods walk-forward evaluates on are not uniformly easier
-or harder than the single held-out final period. That is a property of this
-donor file, not a bug in the splitter.
-
-These numbers, unlike the ones above, are on real donor data. They still
-establish a mechanism and its magnitude on one real file, not a value to
-quote for your program.
-
-The script's output and environment lock are archived separately on Zenodo:
+**Full walkthrough, including the panel construction, the disagreement with the
+prediction, and how to reproduce the run:
+[Real-data replication](real_data_replication.md).** The script's output and
+environment lock are archived on Zenodo at
 [10.5281/zenodo.22050649](https://doi.org/10.5281/zenodo.22050649).
 
 ## Validating on your own data

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -8,3 +8,4 @@ These pages build understanding. They cover the concepts and architecture behind
 * [Responsible Use & Compliance](compliance_considerations.md)
 * [PhilanthroPy vs. Commercial Vendors](comparison_to_vendors.md)
 * [Model Validation & Benchmarks](benchmarks.md)
+* [Real-Data Replication: KDD Cup 1998](real_data_replication.md)

--- a/docs/explanation/real_data_replication.md
+++ b/docs/explanation/real_data_replication.md
@@ -1,0 +1,153 @@
+# Real-Data Replication: KDD Cup 1998
+
+Everything else this project measures is synthetic. This page is not.
+
+The two leakage experiments in [Benchmarks](benchmarks.md) were re-run, unchanged
+in structure, on a real donor file: [KDD Cup 1998](https://kdd.ics.uci.edu/databases/kddcup98/kddcup98.html),
+95,412 donors with a 24-mailing direct-mail history, reshaped into a 22-period
+donor-period panel. The headline: **building features over the whole export
+instead of as of each decision point inflates walk-forward ROC-AUC by +0.376**,
+roughly three times the synthetic effect, and it is the largest single number
+this repository has measured.
+
+## The two questions
+
+Both experiments hold everything constant except one choice.
+
+**A. Does the CV splitter matter?** Random `StratifiedKFold` against walk-forward
+`FiscalYearGroupedSplitter`, each compared to a genuinely held-out final period.
+
+**B. Does feature construction matter?** The same walk-forward CV, run once on
+features computed *as of* each period and once on the same aggregates computed
+over the whole file including future periods. That second one is the mistake this
+library exists to prevent: build features once over the full history, then split.
+
+## Synthetic and real, side by side
+
+Five seeds each, mean ROC-AUC. The synthetic column is
+`scripts/leakage_experiment.py`; the real column is
+`scripts/real_data_leakage_experiment.py`.
+
+### A. Splitter choice
+
+| Evaluation | Synthetic panel | KDD Cup 1998 |
+|---|---:|---:|
+| True future, final period genuinely held out | 0.639 | 0.541 |
+| Walk-forward `FiscalYearGroupedSplitter` | 0.625 (**-0.014**) | 0.482 (**-0.059**) |
+| Random `StratifiedKFold` | 0.608 (**-0.030**) | 0.648 (**+0.107**) |
+
+### B. Feature timing
+
+| Walk-forward CV, features built... | Synthetic panel | KDD Cup 1998 |
+|---|---:|---:|
+| as of each period | 0.625 | 0.482 |
+| over the whole export, including future periods | 0.750 | 0.858 |
+| **inflation** | **+0.126** | **+0.376** |
+
+Same model, same splitter, same label in every column. The only thing that
+changes between the two rows of table B is *when* the aggregate was computed.
+
+## What the real data changed, including where it disagreed
+
+The script carries a prediction recorded in its own docstring **before it was
+run**: real leakage would be *smaller* than the synthetic figures, because real
+giving habits persist without the synthetic generator's manufactured drift
+working against them, so a classifier should already capture more of that
+persistence from as-of history alone. The predicted range was +0.03 to +0.08.
+
+**That prediction was wrong**, by a factor of roughly five, in the direction that
+strengthens this library's argument rather than weakening it. It is reported here
+rather than quietly re-run because a prediction that only survives when it is
+convenient is not a prediction.
+
+Three things came out of the disagreement:
+
+**Leakage is worse on real data, not better.** A real donor's lifetime total
+repeats identically across all 22 of their period-rows, which is a stronger and
+more identity-revealing signal for a leaky feature to exploit than the synthetic
+panel's softer persistence. +0.376 against +0.126.
+
+**Splitter choice matters more here, and in the opposite direction.** Random
+`StratifiedKFold` *overstates* the true future by +0.107 AUC, an order of
+magnitude past the synthetic 0.014-0.030, and reverses the synthetic run's
+finding, where the random split understated it. The familiar claim that a random
+split flatters your backtest reproduces on this real file and did not reproduce
+on the synthetic one.
+
+**Walk-forward CV undershoots the true future here (0.482 against 0.541), where
+in the synthetic run it slightly overshot.** Real promotion response rates swing
+sharply by campaign type, 8% to 22% across the historical mailings, rather than
+drifting smoothly the way the synthetic generator's drift term does. The three
+most-recent periods that walk-forward evaluates on are therefore not uniformly
+easier or harder than the single held-out final period. That is a property of
+this donor file, not a defect in the splitter.
+
+Put together: correct feature timing is worth about six times what correct
+splitter choice is worth on this file (+0.376 against +0.107), and a correct
+splitter does not recover a single point of the feature-timing loss.
+
+## How the panel was built
+
+KDD Cup 1998 ships one row per donor with 24 direct-mail promotions,
+`ADATE_2`..`ADATE_24` (mail date), and, for promotions 3-24, `RAMNT_3`..`RAMNT_24`
+(amount given, absent if no gift). Promotion 2 is the held-out 97NK mailing the
+original competition scores (`TARGET_B` / `TARGET_D`), which is why it has no
+`RAMNT_2`.
+
+Column index does not track calendar order for an individual donor's history,
+because donors are not mailed on identical schedules. It tracks the *campaign's*
+mail date exactly, because every recipient of a given campaign was mailed on the
+same date: `ADATE_2` is 9706 (June 1997) on every row. So promotions 3-24, oldest
+to newest, are exactly the reverse of their column index, for every donor, with
+no per-row date parsing.
+
+That gives 22 chronological periods per donor. Period *p*'s label is "did this
+donor give at period *p+1*", mirroring "gave in the following year" in the
+synthetic panel. For the last historical period, period *p+1* **is** the 97NK
+mailing, so its label is `TARGET_B` itself rather than something derived.
+
+Two caveats worth stating plainly. A donor not mailed a given campaign
+contributes no gift that period, which is indistinguishable in this file from
+being mailed and not responding; both record as zero. And real data has no seed
+to regenerate, so the five seeds vary only the classifier's and the splitters'
+own randomness, not the panel.
+
+## Reproducing it
+
+```bash
+python scripts/real_data_leakage_experiment.py
+```
+
+The script calls
+[`fetch_kdd98_donors`](../reference/datasets.md), which downloads `cup98lrn.zip`
+(~36 MB) from the UCI mirror on first use and caches it under `~/philanthropy_data`
+(override with the `PHILANTHROPY_DATA` environment variable). The download is
+SHA-256 checked against the file served at that URL.
+
+**This is the one function in the package that touches the network, and it only
+does so when you call it.** Everything else is offline by construction and
+`tests/test_no_network.py` enforces that with socket poisoning plus an import
+scan. Nothing about your own donors, gifts, or environment is ever transmitted.
+If your environment has no outbound access, pass `download_if_missing=False` and
+place the archive in the cache directory yourself.
+
+Expect the full run to take several minutes: five seeds times four evaluations
+over a 95,412 x 22 panel, with `RandomForestClassifier(n_estimators=200)`.
+
+The script's output and an environment lock are archived on Zenodo at
+[10.5281/zenodo.22050649](https://doi.org/10.5281/zenodo.22050649), so the
+numbers on this page can be checked without re-downloading anything.
+
+## What this does and does not establish
+
+It establishes that the leakage mechanism this library is designed around is
+real, is larger on a real donor file than on a synthetic one, and is not fixed by
+choosing a better splitter.
+
+It does not establish an accuracy number for your program. One real file is one
+real file, and this one is a 1997 direct-mail acquisition list, not a
+major-gift pipeline. No estimator's *accuracy* benchmark in this project is
+validated on real data; the *leakage mechanism* now is.
+
+For how to run the equivalent check on your own giving history, see
+[Validating on your own data](benchmarks.md#validating-on-your-own-data).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
     - explanation/security_review_answers.md
     - explanation/comparison_to_vendors.md
     - explanation/benchmarks.md
+    - explanation/real_data_replication.md
   - Contributing: contributing.md
   - API Reference:
     - reference/index.md


### PR DESCRIPTION
## Why

The real-data replication is the only measurement in this project that is not synthetic, and it is
the single strongest piece of evidence the JOSS submission has. It was reachable only by scrolling
two-thirds of the way down `benchmarks.md`: no nav entry, no README mention outside the no-network
paragraph, and no reproduction instructions beyond one bare command with no word about the 36 MB
download it triggers.

## What changed

- **New page `docs/explanation/real_data_replication.md`**, in the nav under Explanation and in
  `docs/explanation/index.md`. It adds what the old section had no room for:
  - synthetic and real numbers side by side for **both** experiments, so the +0.126 → +0.376 and the
    0.014-0.030 → +0.107 jumps are readable in one glance;
  - how the 22-period donor-period panel is built out of KDD98's wide `RAMNT_3..24` promotion
    history, including why reverse column order *is* chronological order and the two caveats
    (unmailed vs. mailed-and-declined are indistinguishable; real data has no seed);
  - the pre-registered prediction, that real leakage would be **smaller**, which was wrong by about
    a factor of five, kept as a finding rather than re-run;
  - reproduction: the download size, the cache location, the `PHILANTHROPY_DATA` override, the
    `download_if_missing=False` path for air-gapped environments, and the runtime to expect;
  - what this does and does not establish (one 1997 direct-mail acquisition list is not a
    major-gift pipeline).
- **`benchmarks.md` keeps the two headline tables** and links out for the rest. The measured numbers
  are stated in exactly one place, so the two pages cannot drift apart.
- **README** gains a "Validated on real donor data" section between the no-network paragraph and
  "From your CRM to scores", with the +0.376 number, the wrong prediction, and the Zenodo DOI.

## Verification

```
$ python -m mkdocs build --strict
INFO    -  Documentation built in 2.44 seconds
```

No source under `philanthropy/` is touched.