### PR TITLE
ci: smoke-test the published wheel weekly on three OSes

### DIFF
--- a/.github/workflows/pypi-smoke.yml
+++ b/.github/workflows/pypi-smoke.yml
@@ -1,0 +1,54 @@
+name: Installed package smoke test
+
+# The main CI suite tests the working tree. Nobody tests what PyPI actually
+# serves, which is the only thing a new user or a JOSS reviewer ever runs:
+# `pip install philanthropy`, then the quickstart. This job walks that path on a
+# schedule, so a broken wheel, a missing package-data file, or a dependency that
+# moved under us surfaces here rather than in someone's first five minutes.
+#
+# Windows is deliberately included. The main matrix is Linux plus macOS, so this
+# is the cheapest place to find out that a path join or a
+# `pd.Timestamp.today().normalize()` behaves differently there.
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"   # Mondays 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: pip install philanthropy (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      # Checked out into a subdirectory on purpose. The examples have to come
+      # from somewhere, but a `philanthropy/` package sitting in the working
+      # directory would shadow the installed wheel and this job would silently
+      # test the working tree, which is exactly what it exists not to do.
+      - uses: actions/checkout@v7
+        with:
+          path: repo
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install from PyPI
+        run: pip install philanthropy
+      - name: Assert the import resolves to the wheel, not the checkout
+        shell: bash   # one quoting dialect across all three runners
+        run: |
+          python -c "
+          import pathlib, philanthropy
+          here = pathlib.Path(philanthropy.__file__).resolve()
+          assert 'site-packages' in here.parts, f'not the installed wheel: {here}'
+          print(philanthropy.__version__, here)
+          "
+      - name: Run the quickstart a reviewer would run
+        run: python repo/examples/quickstart.py
+      - name: Run the console script
+        run: philanthropy --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `::error::` annotations on the Files tab. Closes #113.
 - Regression coverage ensuring `MovesManagementClassifier.fit` preserves
   DataFrame column names in `feature_names_in_`. Closes #54.
+- `.github/workflows/pypi-smoke.yml`: a weekly (Mondays 12:00 UTC) and
+  manually dispatchable job that installs the **published wheel** from PyPI on
+  Linux, macOS and Windows, then runs `examples/quickstart.py` and
+  `philanthropy --help`. Every other job tests the working tree; this one tests
+  what `pip install philanthropy` actually serves, which is the only thing a new
+  user or a reviewer runs. The repository is checked out into a subdirectory and
+  the job asserts `philanthropy.__file__` resolves inside `site-packages`, so a
+  `philanthropy/` directory in the working directory cannot silently shadow the
+  wheel and turn this into a second working-tree test. Windows is included
+  because the main matrix is Linux plus macOS.
 ### Fixed
 - `CRMCleaner.transform` no longer silently corrupts complex amounts into
   wrong finite floats: cells holding actual `complex` values are masked to


### PR DESCRIPTION
## Why

Every job in `ci.yml` tests the working tree. Nothing tests what PyPI actually serves, which is the
only thing a new user or a JOSS reviewer ever runs:

> **Installation:** Does installation proceed as outlined in the documentation?

A broken wheel, a missing `package-data` file, or a dependency that moved under us would surface in
someone's first five minutes rather than in CI. Closing #125 required doing this by hand; this makes
it keep happening.

## What it does

`.github/workflows/pypi-smoke.yml`, Mondays 12:00 UTC plus `workflow_dispatch`, on
ubuntu / macos / windows with `fail-fast: false`:

1. `pip install philanthropy` (the published wheel)
2. assert the import resolves inside `site-packages`
3. `python repo/examples/quickstart.py`
4. `philanthropy --help`

## Two details that are load-bearing

**The checkout goes into a subdirectory (`path: repo`).** The examples have to come from somewhere,
but a `philanthropy/` package sitting in the working directory shadows the installed wheel, and this
job would quietly become a second working-tree test, which is exactly what it exists not to be.

**The import step asserts `philanthropy.__file__` is under `site-packages`.** Belt and braces for
the above, so if the layout ever changes the job fails loudly instead of passing for the wrong
reason. Rehearsed locally in both directions:

```
# from a directory with no philanthropy/ present
0.7.0 .../smokeenv/lib/python3.13/site-packages/philanthropy/__init__.py

# from the repo root, where the working tree should shadow it
AssertionError: not the installed wheel: .../PhilanthroPy/philanthropy/__init__.py
exit=1
```

**Windows is in the matrix** because the main one is Linux plus macOS. This is the cheapest place to
learn that a path join or a `pd.Timestamp.today().normalize()` behaves differently there.

## Verification

YAML parses; the four runtime steps were rehearsed locally against the real 0.7.0 wheel in a clean
venv (output above, plus the quickstart printing its ranked pool and `philanthropy --help` printing
its usage line).

What cannot be verified before merge: `schedule` and `workflow_dispatch` workflows only run from the
default branch, so the first real run has to be a manual dispatch after this lands. Worth doing
immediately rather than waiting until Monday.