### PR TITLE
docs: add three CI-executed notebooks, retire quickstart.ipynb as a redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         run: python -m flake8 philanthropy tests examples
       - name: Type check (mypy)
         run: python -m mypy philanthropy
+      # One leg is enough: these exercise the public API against the working
+      # tree, not the OS. --no-cov because pytest-cov's fail_under gate is for
+      # philanthropy/ itself, not notebook cells.
+      - name: Execute example notebooks
+        run: python -m pytest --nbmake examples/notebooks -q --no-cov
 
   test:
     name: Test (${{ matrix.os }}, py${{ matrix.python-version }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
     private generator produced, on all five published seeds. Gift amounts are
     deliberately **not** rounded to cents for that reason; rounding moved the
     reported min-max ranges by 0.001 AUC.
+- **Three notebooks under `examples/notebooks/`**, each with a Colab badge,
+  executed end to end in CI on every push (`pytest --nbmake examples/notebooks`,
+  one leg of the `lint` job): `01_quickstart_propensity.ipynb` (the README
+  quickstart plus a call list, a distribution plot, and permutation
+  importance), `02_temporal_leakage.ipynb` (builds `make_donor_panel`'s
+  features as-of and over the whole export and measures the inflation, an
+  optional cell behind `PHILANTHROPY_FETCH_KDD98` reproduces the real-data
+  number), and `03_grateful_patient_pipeline.ipynb` (encounters, an `as_of`
+  cutoff, service-line weighting, the solicitation window, routed through a
+  `ColumnTransformer` rather than a serial `Pipeline`, with an assertion that
+  the pipeline is not degenerate). `nbmake>=1.5` added to the `dev` extra as a
+  dev-only dependency; the runtime dependency rule (scikit-learn, pandas,
+  numpy, matplotlib, seaborn, nothing else) is untouched.
+  `examples/quickstart.ipynb` becomes a one-cell redirect to notebook 01 for
+  one release, so the previous Colab badge and any existing links keep
+  working; `tests/test_examples.py`'s docstring now says notebooks are covered
+  by `nbmake`, not by it.
 
 ### Deprecated
 - `FiscalYearGroupedSplitter`'s default for `drop_repeat_donors` (currently `False`) is deprecated and will change to `True` in 0.8.0. Leaving it at its default now emits a `DeprecationWarning`. Pass `drop_repeat_donors=False` explicitly to silence the warning and retain current behavior. Closes #108, by @shubhrai23.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ the threshold from your team's capacity, not from this table.
 > data-generating process. They are still synthetic: see
 > [Benchmarks](docs/explanation/benchmarks.md).
 
-> **Try it now, zero install:** [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/quickstart.ipynb)
+> **Try it now, zero install:** [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/notebooks/01_quickstart_propensity.ipynb)
+>
+> **More notebooks:** [`02_temporal_leakage.ipynb`](examples/notebooks/02_temporal_leakage.ipynb) measures where the leakage this library exists to prevent actually comes from; [`03_grateful_patient_pipeline.ipynb`](examples/notebooks/03_grateful_patient_pipeline.ipynb) builds the academic-medical-center path end to end. All three run in CI on every push (`pytest --nbmake`).
 >
 > **Runnable scripts:** [`examples/quickstart.py`](examples/quickstart.py) and [`examples/unischema_to_scores.py`](examples/unischema_to_scores.py) run end to end and are smoke-tested in CI.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,7 +112,7 @@ which is the model reciting its training set, not a result.
     | Non-major donors | 153 | 0.0 | 1.5 | 8.5 | 38.5 | 100.0 |
     | Major donors | 347 | 18.0 | 85.5 | 96.5 | 99.5 | 100.0 |
 
-[Run it in Colab, zero install](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/quickstart.ipynb){ .md-button .md-button--secondary }
+[Run it in Colab, zero install](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/notebooks/01_quickstart_propensity.ipynb){ .md-button .md-button--secondary }
 
 ## What is PhilanthroPy?
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,3 +14,18 @@ python examples/quickstart.py
 | [`quickstart.py`](quickstart.py) | Train `DonorPropensityModel` on synthetic donors, rank a held-out pool by 0–100 affinity score. |
 | [`unischema_to_scores.py`](unischema_to_scores.py) | The ecosystem flow: a [UniSchema](https://github.com/PhilanthroPy-Project/UniSchema) `ConstituentEvent` stream → donor features → scores, no glue code. |
 | [`method_reference_lalakiya2025.py`](method_reference_lalakiya2025.py) | Reference implementation of the method in [Lalakiya 2025 (ICCED)](https://doi.org/10.1109/ICCED68324.2025.11325064): RFM → classifier panel → permutation importance → correlation, on synthetic donor data. |
+
+## Notebooks
+
+Under [`notebooks/`](notebooks/), each with a Colab badge, executed end to end in CI on every push
+(`pytest --nbmake examples/notebooks`, one leg of the `lint` job so an API change breaks the
+notebook before it breaks a reader's copy-paste):
+
+| Notebook | What it shows |
+|---|---|
+| [`01_quickstart_propensity.ipynb`](notebooks/01_quickstart_propensity.ipynb) | The README quickstart, plus a call list, a distribution plot, and permutation importance. |
+| [`02_temporal_leakage.ipynb`](notebooks/02_temporal_leakage.ipynb) | Builds the same features two ways, as-of each year versus over the whole export, and measures the inflation. This is the library's central argument. |
+| [`03_grateful_patient_pipeline.ipynb`](notebooks/03_grateful_patient_pipeline.ipynb) | The academic-medical-center path: encounters, an `as_of` cutoff, service-line weighting, the solicitation window, routed through a `ColumnTransformer`. |
+
+`examples/quickstart.ipynb` is a redirect to `01_quickstart_propensity.ipynb`, kept for one release
+so old links do not break.

--- a/examples/notebooks/01_quickstart_propensity.ipynb
+++ b/examples/notebooks/01_quickstart_propensity.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3fb688af",
+   "metadata": {},
+   "source": [
+    "# 1. Rank donors by major-gift propensity\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/notebooks/01_quickstart_propensity.ipynb)\n",
+    "\n",
+    "Fit a propensity model on a synthetic donor pool, score a held-out set, and read\n",
+    "the result honestly. About a minute end to end.\n",
+    "\n",
+    "What you get by the last cell: a ranked prospect list, the held-out ROC-AUC that\n",
+    "ranking is worth, which signals moved the score, and a picture of how much the\n",
+    "two groups overlap.\n",
+    "\n",
+    "Everything here is synthetic. It demonstrates the workflow, not a number to\n",
+    "quote for your own program."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41cdbb2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Colab and other fresh environments only; a local checkout already has it.\n",
+    "try:\n",
+    "    import philanthropy\n",
+    "except ImportError:\n",
+    "    !pip install -q \"philanthropy[viz]\"\n",
+    "    import philanthropy\n",
+    "\n",
+    "print(\"philanthropy\", philanthropy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2810d23b",
+   "metadata": {},
+   "source": [
+    "## Fit and score\n",
+    "\n",
+    "Split before fitting. Scoring the rows you trained on tells you nothing: a\n",
+    "random forest's leaves go pure, so it recites its training set and reports a\n",
+    "gap that will not survive contact with next year's data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9adb7897",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "from philanthropy.datasets import generate_synthetic_donor_data\n",
+    "from philanthropy.models import DonorPropensityModel\n",
+    "\n",
+    "FEATURES = [\"total_gift_amount\", \"years_active\", \"event_attendance_count\"]\n",
+    "\n",
+    "df = generate_synthetic_donor_data(n_samples=2000, random_state=42)\n",
+    "X = df[FEATURES].to_numpy()\n",
+    "y = df[\"is_major_donor\"].to_numpy()\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.25, stratify=y, random_state=42\n",
+    ")\n",
+    "\n",
+    "model = DonorPropensityModel(n_estimators=200, random_state=0)\n",
+    "model.fit(X_train, y_train)\n",
+    "\n",
+    "scores = model.predict_affinity_score(X_test)   # 0-100, not a probability\n",
+    "auc = roc_auc_score(y_test, model.predict_proba(X_test)[:, 1])\n",
+    "print(f\"held-out ROC-AUC: {auc:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e771a83d",
+   "metadata": {},
+   "source": [
+    "## The call list\n",
+    "\n",
+    "`predict_affinity_score` returns a 0-100 rank, not a calibrated probability.\n",
+    "Sort by it and hand your officers the top of the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f09f38c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prospects = pd.DataFrame(X_test, columns=FEATURES)\n",
+    "prospects[\"affinity_score\"] = scores\n",
+    "prospects.sort_values(\"affinity_score\", ascending=False).head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60bbdc06",
+   "metadata": {},
+   "source": [
+    "## Read it honestly\n",
+    "\n",
+    "Now look at the two distributions rather than the headline number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31909f36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.Series(scores).groupby(y_test).describe()[[\"count\", \"mean\", \"min\", \"max\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "311eb078",
+   "metadata": {},
+   "source": [
+    "The distributions **overlap**. Some non-major donors score in the nineties and\n",
+    "some major donors score near zero. Ranking works; clean separation does not\n",
+    "exist, and a list cut at any single threshold will contain mistakes.\n",
+    "\n",
+    "Pick the threshold from your team's capacity, not from this table. If forty\n",
+    "visits is what the quarter allows, take the top forty and stop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cd49e76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from philanthropy.visualisation import plot_affinity_distribution\n",
+    "\n",
+    "ax = plot_affinity_distribution(scores, labels=y_test)\n",
+    "ax.figure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3038cbf",
+   "metadata": {},
+   "source": [
+    "## Which signals moved the score\n",
+    "\n",
+    "Permutation importance, measured against the held-out split rather than the\n",
+    "training data, because attribution scored on data the model memorised tells you\n",
+    "about the memorisation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8516feb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from philanthropy.inspection import donor_feature_importance\n",
+    "\n",
+    "donor_feature_importance(\n",
+    "    model, X_test, y_test, feature_names=FEATURES, random_state=0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f35de91",
+   "metadata": {},
+   "source": [
+    "## Next\n",
+    "\n",
+    "- **[2. Where the leakage actually is](02_temporal_leakage.ipynb)**: the same\n",
+    "  kind of model, measured properly across time. This is the one that matters.\n",
+    "- **[3. A grateful-patient pipeline](03_grateful_patient_pipeline.ipynb)**: the\n",
+    "  academic-medical-center path, with clinical encounters.\n",
+    "\n",
+    "`total_gift_amount` carrying most of the signal above is a warning, not a\n",
+    "result: predicting \"is a major donor\" from cumulative lifetime giving is\n",
+    "close to predicting the label from itself. Notebook 2 is about exactly this\n",
+    "class of mistake."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02_temporal_leakage.ipynb
+++ b/examples/notebooks/02_temporal_leakage.ipynb
@@ -1,0 +1,309 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "386e2a13",
+   "metadata": {},
+   "source": [
+    "# 2. Where the leakage actually is\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/notebooks/02_temporal_leakage.ipynb)\n",
+    "\n",
+    "Two questions, measured rather than asserted:\n",
+    "\n",
+    "**A. Does the cross-validation splitter matter?** Random `StratifiedKFold`\n",
+    "against walk-forward `FiscalYearGroupedSplitter`, both compared to a genuinely\n",
+    "held-out future year.\n",
+    "\n",
+    "**B. Does *when* you build the features matter?** The same walk-forward split,\n",
+    "run once on aggregates computed **as of** each year and once on the same\n",
+    "aggregates computed over the **whole** export, including years that had not\n",
+    "happened yet.\n",
+    "\n",
+    "The received wisdom says A is the important one. It is not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f3947ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from philanthropy.datasets import make_donor_panel\n",
+    "except ImportError:\n",
+    "    # make_donor_panel is newer than the current PyPI release.\n",
+    "    !pip install -q \"philanthropy @ git+https://github.com/PhilanthroPy-Project/PhilanthroPy@main\"\n",
+    "    from philanthropy.datasets import make_donor_panel\n",
+    "\n",
+    "import philanthropy\n",
+    "print(\"philanthropy\", philanthropy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2de73649",
+   "metadata": {},
+   "source": [
+    "## A panel, not a flat table\n",
+    "\n",
+    "`make_donor_panel` returns what a fundraising shop actually exports: one row per\n",
+    "**gift**, with a fiscal year attached. Nothing is pre-aggregated, because\n",
+    "aggregation is the subject."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb730279",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "N_DONORS = 1500\n",
+    "YEARS = list(range(2018, 2025))\n",
+    "\n",
+    "panel = make_donor_panel(\n",
+    "    n_donors=N_DONORS, n_years=len(YEARS), start_fiscal_year=YEARS[0], random_state=42\n",
+    ")\n",
+    "gifts = panel[\"gifts\"]\n",
+    "gifts.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dc2f40b",
+   "metadata": {},
+   "source": [
+    "## Build the features twice\n",
+    "\n",
+    "Identical aggregates. The only difference is the slice they are computed over.\n",
+    "\n",
+    "`as_of` uses `amount[:, :j+1]`, everything up to and including the year being\n",
+    "scored. `whole` uses `amount`, the entire export. That single character is the\n",
+    "whole experiment, and it is the mistake this library exists to prevent: build\n",
+    "features once over the full history, split afterwards, and the future has\n",
+    "already leaked into every training row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd5a99c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "amount = np.zeros((N_DONORS, len(YEARS)))\n",
+    "amount[gifts[\"donor_id\"], gifts[\"fiscal_year\"] - YEARS[0]] = gifts[\"gift_amount\"]\n",
+    "gave = amount > 0\n",
+    "\n",
+    "FEATURES = [\"total\", \"n\", \"recent\"]\n",
+    "\n",
+    "\n",
+    "def build(as_of):\n",
+    "    frames = []\n",
+    "    for j, year in enumerate(YEARS[:-1]):\n",
+    "        common = dict(\n",
+    "            fy=year,\n",
+    "            recent=amount[:, j],\n",
+    "            y=gave[:, j + 1].astype(int),   # gave in the FOLLOWING year\n",
+    "        )\n",
+    "        if as_of:\n",
+    "            frames.append(pd.DataFrame(dict(\n",
+    "                total=amount[:, : j + 1].sum(1), n=gave[:, : j + 1].sum(1), **common\n",
+    "            )))\n",
+    "        else:\n",
+    "            frames.append(pd.DataFrame(dict(\n",
+    "                total=amount.sum(1), n=gave.sum(1), **common\n",
+    "            )))\n",
+    "    return pd.concat(frames, ignore_index=True)\n",
+    "\n",
+    "\n",
+    "as_of_df, whole_df = build(True), build(False)\n",
+    "print(as_of_df.shape, whole_df.shape)\n",
+    "as_of_df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "870f5543",
+   "metadata": {},
+   "source": [
+    "## The honest target\n",
+    "\n",
+    "\"Train on everything before the final year, score the final year.\" That is the\n",
+    "number every backtest is trying to estimate, so measure it directly and compare\n",
+    "the estimators against it.\n",
+    "\n",
+    "Both cross-validations below **exclude** the final year, for the same reason: it\n",
+    "is the estimand. Leaving it in would put it inside one estimator and not the\n",
+    "other, and walk-forward would win by construction rather than on merit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f5a9d41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.metrics import roc_auc_score\n",
+    "from sklearn.model_selection import StratifiedKFold, cross_val_score\n",
+    "\n",
+    "from philanthropy.model_selection import FiscalYearGroupedSplitter\n",
+    "\n",
+    "\n",
+    "def clf():\n",
+    "    return RandomForestClassifier(n_estimators=100, random_state=0)\n",
+    "\n",
+    "\n",
+    "def true_future(df):\n",
+    "    X, y, fy = df[FEATURES].to_numpy(), df[\"y\"].to_numpy(), df[\"fy\"].to_numpy()\n",
+    "    train, test = fy < fy.max(), fy == fy.max()\n",
+    "    fitted = clf().fit(X[train], y[train])\n",
+    "    return roc_auc_score(y[test], fitted.predict_proba(X[test])[:, 1])\n",
+    "\n",
+    "\n",
+    "def cv(df, splitter, use_groups):\n",
+    "    df = df[df[\"fy\"] < df[\"fy\"].max()]\n",
+    "    X, y, fy = df[FEATURES].to_numpy(), df[\"y\"].to_numpy(), df[\"fy\"].to_numpy()\n",
+    "    kwargs = {\"groups\": fy} if use_groups else {}\n",
+    "    return cross_val_score(\n",
+    "        clf(), X, y, cv=splitter, scoring=\"roc_auc\", **kwargs\n",
+    "    ).mean()\n",
+    "\n",
+    "\n",
+    "truth = true_future(as_of_df)\n",
+    "walk = cv(as_of_df, FiscalYearGroupedSplitter(n_splits=3, drop_repeat_donors=False), True)\n",
+    "random = cv(as_of_df, StratifiedKFold(5, shuffle=True, random_state=0), False)\n",
+    "leaky = cv(whole_df, FiscalYearGroupedSplitter(n_splits=3, drop_repeat_donors=False), True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8d2f9b1",
+   "metadata": {},
+   "source": [
+    "## Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fced918",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"ROC-AUC\": [truth, walk, random],\n",
+    "        \"error vs the true future\": [np.nan, walk - truth, random - truth],\n",
+    "    },\n",
+    "    index=[\n",
+    "        \"true future, final year held out\",\n",
+    "        \"walk-forward FiscalYearGroupedSplitter\",\n",
+    "        \"random StratifiedKFold\",\n",
+    "    ],\n",
+    ").round(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d422e252",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame(\n",
+    "    {\"ROC-AUC\": [walk, leaky, leaky - walk]},\n",
+    "    index=[\n",
+    "        \"features built as of each year\",\n",
+    "        \"same features over the whole export\",\n",
+    "        \"INFLATION\",\n",
+    "    ],\n",
+    ").round(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b461d206",
+   "metadata": {},
+   "source": [
+    "## What that says\n",
+    "\n",
+    "Same model, same splitter, same label. The only difference in the second table\n",
+    "is *when* the aggregate was computed, and it is worth several times what the\n",
+    "splitter choice is worth. **No choice of splitter recovers it.**\n",
+    "\n",
+    "That is why every fitted statistic in this package is computed in `fit` and\n",
+    "frozen before `transform`, and why `EncounterTransformer` and\n",
+    "`GratefulPatientFeaturizer` take an `as_of` cutoff.\n",
+    "\n",
+    "These are synthetic numbers on a generator whose persistence and drift were\n",
+    "chosen. On a **real** donor file, KDD Cup 1998, 95,412 donors, the same\n",
+    "experiment gives **+0.376 AUC** of inflation, roughly three times the synthetic\n",
+    "effect, against +0.107 for the splitter. Full write-up:\n",
+    "[Real-data replication](https://philanthropy-project.github.io/PhilanthroPy/explanation/real_data_replication/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7ac9b87",
+   "metadata": {},
+   "source": [
+    "## Optional: reproduce the real-data number\n",
+    "\n",
+    "The cell below downloads KDD Cup 1998 (~36 MB) from the UCI mirror and takes a\n",
+    "few minutes. It is off unless you ask for it, and it is the only function in\n",
+    "this package that touches the network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efc45dfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "if os.environ.get(\"PHILANTHROPY_FETCH_KDD98\"):\n",
+    "    from philanthropy.datasets import fetch_kdd98_donors\n",
+    "\n",
+    "    real = fetch_kdd98_donors()\n",
+    "    print(f\"{len(real):,} donors, {real.shape[1]} columns\")\n",
+    "    print(\"Full experiment: python scripts/real_data_leakage_experiment.py\")\n",
+    "else:\n",
+    "    print(\"Skipped. Set PHILANTHROPY_FETCH_KDD98=1 to run it.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f2757e3",
+   "metadata": {},
+   "source": [
+    "## Next\n",
+    "\n",
+    "**[3. A grateful-patient pipeline](03_grateful_patient_pipeline.ipynb)**, where\n",
+    "the `as_of` cutoff stops being an argument and starts being a parameter you\n",
+    "have to pass."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/03_grateful_patient_pipeline.ipynb
+++ b/examples/notebooks/03_grateful_patient_pipeline.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "59edf4bb",
+   "metadata": {},
+   "source": [
+    "# 3. A grateful-patient pipeline\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/notebooks/03_grateful_patient_pipeline.ipynb)\n",
+    "\n",
+    "Academic medical centers have a channel most nonprofits do not: patients who\n",
+    "give because of the care they received. This notebook turns clinical encounters\n",
+    "into model-ready features and scores prospects with them.\n",
+    "\n",
+    "> **Read this before doing it for real.** The PII handling in these transformers\n",
+    "> is a narrow read surface, **not** formal HIPAA de-identification, and the\n",
+    "> service-line capacity weights are illustrative with no published source. See\n",
+    "> [Compliance considerations](https://philanthropy-project.github.io/PhilanthroPy/explanation/compliance_considerations/).\n",
+    "> Every number below is synthetic; no real patient data appears anywhere in this\n",
+    "> package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ee6ae53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from philanthropy.datasets import make_donor_panel\n",
+    "except ImportError:\n",
+    "    !pip install -q \"philanthropy @ git+https://github.com/PhilanthroPy-Project/PhilanthroPy@main\"\n",
+    "    from philanthropy.datasets import make_donor_panel\n",
+    "\n",
+    "import philanthropy\n",
+    "print(\"philanthropy\", philanthropy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7156948b",
+   "metadata": {},
+   "source": [
+    "## Two tables\n",
+    "\n",
+    "Encounters join to donors on an identifier that never reaches the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a25f29e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "panel = make_donor_panel(\n",
+    "    n_donors=800, n_years=5, include_encounters=True, random_state=7\n",
+    ")\n",
+    "gifts, donors, encounters = panel[\"gifts\"], panel[\"donors\"], panel[\"encounters\"]\n",
+    "\n",
+    "print(f\"{len(donors)} donors, {len(gifts)} gifts, {len(encounters)} encounters\")\n",
+    "encounters.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff2df303",
+   "metadata": {},
+   "source": [
+    "## Encounter dates are drawn independently of giving\n",
+    "\n",
+    "Worth saying out loud, because it is what makes the exercise meaningful. A\n",
+    "generator that made grateful-patient features predictive by construction would\n",
+    "be a very convincing demonstration of nothing. Any signal the model finds below\n",
+    "comes from the label being built out of encounter history, not from the\n",
+    "generator quietly correlating the two."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fd246c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# One row per donor, with their most recent gift date as the decision point.\n",
+    "X = (\n",
+    "    gifts.groupby(\"donor_id\", as_index=False)[\"gift_date\"].max()\n",
+    "    .merge(donors, on=\"donor_id\", how=\"right\")\n",
+    ")\n",
+    "X[\"gift_date\"] = X[\"gift_date\"].fillna(gifts[\"gift_date\"].max())\n",
+    "# EncounterTransformer currently raises on a real datetime64 gift_date column\n",
+    "# and only accepts date strings (philanthropy#163); this round-trip is the\n",
+    "# workaround, not the recommended pattern.\n",
+    "X[\"gift_date\"] = X[\"gift_date\"].dt.strftime(\"%Y-%m-%d\")\n",
+    "\n",
+    "# The label: donors seen three or more times. Synthetic, and deliberately a\n",
+    "# function of the encounter table, so there is something real to recover.\n",
+    "counts = encounters[\"donor_id\"].value_counts()\n",
+    "y = (X[\"donor_id\"].map(counts).fillna(0) >= 3).astype(int).to_numpy()\n",
+    "print(\"base rate\", y.mean().round(3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af163720",
+   "metadata": {},
+   "source": [
+    "## `as_of` is not optional\n",
+    "\n",
+    "`EncounterTransformer(as_of=...)` drops every encounter discharged after the\n",
+    "cutoff. Without it you are building today's features out of admissions that had\n",
+    "not happened when the decision was made, which is notebook 2's mistake wearing\n",
+    "a lab coat.\n",
+    "\n",
+    "Below, the cutoff is set a year before the end of the data, and the difference\n",
+    "it makes is measured rather than asserted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b4aaed9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from philanthropy.preprocessing import EncounterTransformer\n",
+    "\n",
+    "cutoff = encounters[\"discharge_date\"].max() - pd.Timedelta(days=365)\n",
+    "\n",
+    "cols = [\"donor_id\", \"gift_date\"]\n",
+    "\n",
+    "\n",
+    "def encounter_features(as_of):\n",
+    "    t = EncounterTransformer(\n",
+    "        encounter_df=encounters,\n",
+    "        discharge_col=\"discharge_date\",\n",
+    "        gift_date_col=\"gift_date\",\n",
+    "        merge_key=\"donor_id\",\n",
+    "        as_of=as_of,\n",
+    "    )\n",
+    "    t.set_output(transform=\"pandas\")\n",
+    "    return t.fit_transform(X[cols])\n",
+    "\n",
+    "\n",
+    "with_cutoff = encounter_features(cutoff)\n",
+    "without_cutoff = encounter_features(None)\n",
+    "\n",
+    "pd.DataFrame({\n",
+    "    \"as_of set\": with_cutoff[\"encounter_frequency_score\"].describe(),\n",
+    "    \"as_of unset (leaks)\": without_cutoff[\"encounter_frequency_score\"].describe(),\n",
+    "}).round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5ea2d59",
+   "metadata": {},
+   "source": [
+    "The unset column counts encounters that had not happened yet. On real data that\n",
+    "difference is free accuracy in your backtest and none in production.\n",
+    "\n",
+    "## Service-line weighting\n",
+    "\n",
+    "`GratefulPatientFeaturizer` reads only encounter metadata: service line,\n",
+    "attending physician, dates. Four numeric aggregates come out and no identifier\n",
+    "does. Capacity weighting is **off by default**, because the built-in multipliers\n",
+    "are illustrative and turning them on silently would launder a guess into a\n",
+    "headline score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3b14ddd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from philanthropy.preprocessing import GratefulPatientFeaturizer\n",
+    "\n",
+    "gpf = GratefulPatientFeaturizer(encounter_df=encounters)\n",
+    "clinical = pd.DataFrame(\n",
+    "    gpf.fit_transform(X[[\"donor_id\"]]), columns=gpf.get_feature_names_out()\n",
+    ")\n",
+    "clinical.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "595caa1e",
+   "metadata": {},
+   "source": [
+    "## The solicitation window\n",
+    "\n",
+    "Patients 90 to 365 days post-discharge are often the warmest prospects: long\n",
+    "enough that the visit is not raw, recent enough that it is not forgotten.\n",
+    "`window_position_score` peaks at the midpoint and falls to zero at either edge."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af6b74f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from philanthropy.preprocessing import DischargeToSolicitationWindowTransformer\n",
+    "\n",
+    "window = DischargeToSolicitationWindowTransformer()\n",
+    "scored = pd.DataFrame(\n",
+    "    window.fit_transform(with_cutoff[[\"days_since_last_discharge\"]]),\n",
+    "    columns=window.get_feature_names_out(),\n",
+    ")\n",
+    "print(\"in window:\", int(scored[\"in_solicitation_window\"].sum()), \"of\", len(scored))\n",
+    "scored.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18700f3c",
+   "metadata": {},
+   "source": [
+    "## Route with `ColumnTransformer`, not a serial `Pipeline`\n",
+    "\n",
+    "Each of these transformers consumes named columns and replaces them. Chained in\n",
+    "series, the second receives the first's output under the wrong names, produces a\n",
+    "constant feature block, and trains a model on nothing while exiting 0. A\n",
+    "`ColumnTransformer` hands each branch exactly the columns it wants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86ba284a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.compose import ColumnTransformer\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "\n",
+    "from philanthropy.models import MajorGiftClassifier\n",
+    "from philanthropy.preprocessing import CRMCleaner\n",
+    "\n",
+    "pipeline = Pipeline([\n",
+    "    (\"features\", ColumnTransformer(\n",
+    "        transformers=[\n",
+    "            (\"encounters\", EncounterTransformer(\n",
+    "                encounter_df=encounters,\n",
+    "                discharge_col=\"discharge_date\",\n",
+    "                gift_date_col=\"gift_date\",\n",
+    "                merge_key=\"donor_id\",\n",
+    "                as_of=cutoff,\n",
+    "            ), [\"donor_id\", \"gift_date\"]),\n",
+    "            (\"clinical\", GratefulPatientFeaturizer(encounter_df=encounters), [\"donor_id\"]),\n",
+    "            (\"crm\", CRMCleaner(), [\"wealth_estimate\"]),\n",
+    "        ],\n",
+    "        remainder=\"drop\",\n",
+    "    )),\n",
+    "    # MajorGiftClassifier handles NaN natively, so the ~30% missing wealth\n",
+    "    # estimates need no upstream imputation.\n",
+    "    (\"model\", MajorGiftClassifier(max_iter=50, random_state=42)),\n",
+    "])\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    X, y, test_size=0.25, stratify=y, random_state=0\n",
+    ")\n",
+    "pipeline.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f822e111",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.metrics import roc_auc_score\n",
+    "\n",
+    "proba = pipeline.predict_proba(X_test)[:, 1]\n",
+    "print(f\"held-out ROC-AUC: {roc_auc_score(y_test, proba):.3f}\")\n",
+    "\n",
+    "# A constant score means the features never reached the model: exactly the\n",
+    "# failure the ColumnTransformer prevents. Assert it, do not eyeball it.\n",
+    "assert len(set(proba.round(6))) > 1, \"degenerate pipeline: every score identical\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35da4954",
+   "metadata": {},
+   "source": [
+    "## What to take from this\n",
+    "\n",
+    "The pipeline shape matters more than the estimator. `as_of` on the encounter\n",
+    "step, `ColumnTransformer` rather than a serial chain, capacity weights off until\n",
+    "your institution has reviewed them, and a compliance read before any of it\n",
+    "touches a real EHR export.\n",
+    "\n",
+    "Then re-validate on your own data. These numbers are synthetic and say nothing\n",
+    "about your program."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -4,37 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# PhilanthroPy Quick Start\n",
+    "# This notebook has moved\n",
     "\n",
-    "Score a synthetic donor pool in under a minute, no local setup. Run this in Google Colab (Runtime → Run all)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install philanthropy -q"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from philanthropy.datasets import generate_synthetic_donor_data\n",
-    "from philanthropy.models import DonorPropensityModel\n",
+    "`examples/quickstart.ipynb` is now\n",
+    "[`examples/notebooks/01_quickstart_propensity.ipynb`](notebooks/01_quickstart_propensity.ipynb),\n",
+    "one of three notebooks executed by CI on every push. This redirect stays at the old path for one\n",
+    "release so existing links and the previous Colab badge keep working, then it is removed.\n",
     "\n",
-    "df = generate_synthetic_donor_data(n_samples=500, random_state=42)\n",
-    "X = df[[\"total_gift_amount\", \"years_active\", \"event_attendance_count\"]].to_numpy()\n",
-    "y = df[\"is_major_donor\"].to_numpy()\n",
-    "\n",
-    "model = DonorPropensityModel(n_estimators=200, random_state=0)\n",
-    "model.fit(X, y)\n",
-    "df[\"affinity_score\"] = model.predict_affinity_score(X)  # 0–100 affinity scale\n",
-    "df[[\"total_gift_amount\", \"years_active\", \"affinity_score\"]].head(10)"
+    "**[Open the new notebook in Colab](https://colab.research.google.com/github/PhilanthroPy-Project/PhilanthroPy/blob/main/examples/notebooks/01_quickstart_propensity.ipynb)**"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ dev = [
     "flake8>=6.0",
     "mypy>=1.0",
     "matplotlib>=3.6",
-    "seaborn>=0.13"
+    "seaborn>=0.13",
+    "nbmake>=1.5"
 ]
 docs = [
     "mkdocs>=1.4.0,<2",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,10 @@
 
 Keeps the examples honest: if the public API drifts, ``main()`` breaks here
 before it breaks for a user copy-pasting from the docs.
+
+Notebooks under ``examples/notebooks/`` are covered separately, by
+``pytest --nbmake examples/notebooks`` in the ``lint`` job of ``ci.yml``, not
+by this file: a notebook has no ``main()`` to call.
 """
 
 import importlib.util


### PR DESCRIPTION
## Why

The one existing notebook, `examples/quickstart.ipynb`, was two cells and never run by CI: last
verified against the 0.6.0 wheel, and nothing would have caught it silently going stale. It also
could not show the library's central idea, because the synthetic generator it used has no gift log
or repeated years to build `as_of` features from.

## What changed

`examples/notebooks/`, three notebooks, each with a Colab badge, executed end to end on every push
via `pytest --nbmake examples/notebooks` (one leg of the `lint` job; `nbmake>=1.5` added to the `dev`
extra only, the runtime dependency rule is untouched):

- **`01_quickstart_propensity.ipynb`**: the README quickstart, plus a ranked call list, the
  overlap-distribution plot, and permutation importance.
- **`02_temporal_leakage.ipynb`**: builds `make_donor_panel`'s features two ways, as of each year and
  over the whole export, and measures the inflation directly. An optional cell behind
  `PHILANTHROPY_FETCH_KDD98` reproduces the real-data number without forcing a 36 MB download on
  everyone else.
- **`03_grateful_patient_pipeline.ipynb`**: encounters → an `as_of` cutoff → service-line weighting →
  the solicitation window, routed through a `ColumnTransformer` rather than a serial `Pipeline` (the
  same degenerate-pipeline failure the existing tutorial guards against), with an assertion that the
  scores are not constant rather than an eyeball check.

`examples/quickstart.ipynb` becomes a one-cell redirect to notebook 1 for one release, so the
previous Colab badge and any existing links keep working. README and `docs/index.md` point at the
new notebook. `tests/test_examples.py`'s docstring now says notebooks are covered by `nbmake`, since
a notebook has no `main()` to call.

## A defect the build surfaced, not routed around

`EncounterTransformer` rejects a real `datetime64` `gift_date` column and only accepts date strings
(filed as **#163**, found while writing `make_donor_panel` in #162). Notebook 3 works around it with
a `strftime` round-trip and a comment pointing at the issue, matching the identical workaround
already in `tests/test_donor_panel.py`.

## Verification

```
$ python -m pytest --nbmake examples/notebooks -q
3 passed
$ python -m flake8 philanthropy tests examples
(clean)
$ python -m mkdocs build --strict
(clean)
```

Notebooks were normalized (`nbformat.validator.normalize`) to add missing cell IDs, so there is no
`MissingIDFieldWarning` noise in the nbmake output.