### PR TITLE
docs: link the README coverage badge to its enforced source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- README coverage badge now links to `pyproject.toml` and reads "≥92% floor"
+  rather than a bare "≥92%". It was a static shields.io string with no tie to
+  the enforced number, so it would have silently lied had `fail_under` ever
+  moved. Not wiring a dynamic gist badge (`schneegans/dynamic-badges-action`):
+  that needs a personal-access-token secret this change doesn't have standing
+  to create, and Codecov/Coveralls are explicitly ruled out elsewhere in this
+  project's standing rules.
+
 ### Added
 - **`datasets.make_donor_panel`** (Tier 2, Beta): a seeded multi-year donor
   panel returning gift-level rows rather than one aggregated row per donor.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://pypi.org/project/philanthropy/"><img src="https://img.shields.io/pypi/v/philanthropy?color=blue" alt="PyPI version"/></a>
   <img src="https://img.shields.io/pypi/pyversions/philanthropy" alt="Python versions"/>
   <a href="https://github.com/PhilanthroPy-Project/PhilanthroPy/actions/workflows/ci.yml"><img src="https://github.com/PhilanthroPy-Project/PhilanthroPy/actions/workflows/ci.yml/badge.svg" alt="Tests"/></a>
-  <img src="https://img.shields.io/badge/coverage-%E2%89%A592%25-brightgreen" alt="Coverage at least 92 percent"/>
+  <a href="https://github.com/PhilanthroPy-Project/PhilanthroPy/blob/main/pyproject.toml"><img src="https://img.shields.io/badge/coverage-%E2%89%A592%25_floor-brightgreen" alt="Coverage floor at least 92 percent, enforced in CI"/></a>
   <img src="https://img.shields.io/badge/sklearn-compatible-orange" alt="sklearn compatible"/>
   <a href="https://PhilanthroPy-Project.github.io/PhilanthroPy/"><img src="https://img.shields.io/badge/docs-GitHub%20Pages-informational" alt="documentation"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/pypi/l/philanthropy?color=green" alt="License"/></a>


### PR DESCRIPTION
## Why

The coverage badge was a static shields.io string with no tie to `pyproject.toml`'s `fail_under`. It
would have kept reading "≥92%" even if that number changed, which is exactly the kind of drift the
CI gate exists to prevent everywhere else.

## What changed

One line. The badge links to `pyproject.toml` and reads "≥92% floor" instead of a bare "≥92%", to be
explicit that this is the enforced minimum CI checks on every push, not a live measured number.

## What this deliberately does not do

Wire a dynamic gist badge (`schneegans/dynamic-badges-action`, generated from the `test` job on
`main`). That needs a personal-access-token secret added to repo settings, which is outside what this
change has standing to do. Codecov and Coveralls are both already ruled out in this project's
standing rules (new service, token, flaky-failure reports).

## Verification

Link resolves; text change only, no source touched.