### PR TITLE
types: annotate model_selection and extend the mypy ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,9 +202,11 @@ entry is mid-deprecation.
   `.inspection`, `.metrics`, `.utils` and `.visualisation` are now fully
   annotated and listed under a `[[tool.mypy.overrides]]` block with
   `disallow_untyped_defs = true`, so a new unannotated function in any of them
-  fails CI rather than enlarging the backlog. `cli` is now annotated and
-  listed too. `model_selection` and `experimental` (both open PRs), plus
-  `models` and `preprocessing`, remain, tracked in #166.
+  fails CI rather than enlarging the backlog. `cli` and `model_selection` are
+  now annotated and listed too (`split`'s generator return is
+  `Iterator[Tuple[ndarray, ndarray]]`, matching its `Yields` docstring
+  section). `experimental` (open PR), `models` and `preprocessing` remain,
+  tracked in #166.
 - `ensure_local_path` is now generic in its argument (`TypeVar`) rather than
   declared `-> str`. It returns its input unchanged, and both call sites pass
   something that may be a `Path`, so the old annotation was a small lie; the

--- a/philanthropy/model_selection/_temporal_donor_splitter.py
+++ b/philanthropy/model_selection/_temporal_donor_splitter.py
@@ -36,6 +36,7 @@ True
 from __future__ import annotations
 
 import warnings
+from typing import Any, Iterator, Tuple
 
 import numpy as np
 from sklearn.model_selection import BaseCrossValidator
@@ -231,7 +232,9 @@ class FiscalYearGroupedSplitter(BaseCrossValidator):
             raise ValueError(f"gap_years must be >= 0, got {gap_years}.")
         return n_splits, gap_years
 
-    def split(self, X, y=None, groups=None):
+    def split(
+        self, X: Any, y: Any = None, groups: Any = None
+    ) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """Generate (train_indices, test_indices) arrays.
 
         Parameters
@@ -389,7 +392,9 @@ class FiscalYearGroupedSplitter(BaseCrossValidator):
 
 
 
-    def get_n_splits(self, X=None, y=None, groups=None) -> int:
+    def get_n_splits(
+        self, X: Any = None, y: Any = None, groups: Any = None
+    ) -> int:
         """Return the number of splits this splitter will produce.
 
         Parameters
@@ -428,7 +433,7 @@ class FiscalYearGroupedSplitter(BaseCrossValidator):
 # Utility: resolve n_samples from various input types
 # ---------------------------------------------------------------------------
 
-def _missing_mask(values) -> np.ndarray:
+def _missing_mask(values: Any) -> np.ndarray:
     """True where a donor identifier is missing.
 
     ``np.isnan`` only works on float arrays, and donor ids are commonly object
@@ -442,7 +447,7 @@ def _missing_mask(values) -> np.ndarray:
     return np.array([v is None or v != v for v in arr.ravel()]).reshape(arr.shape)
 
 
-def _n_samples(X) -> int:
+def _n_samples(X: Any) -> int:
     """Return the number of samples from X, supporting ndarray and DataFrames."""
     if X is None:
         raise ValueError("X must not be None.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,14 +109,15 @@ ignore_missing_imports = true
 # Add a module to this list in the same PR that annotates it; when every
 # subpackage is listed, delete the override and set the flag at the top level.
 #
-# Still to do (count at the time of writing): model_selection 4 (open PR),
-# experimental 5 (open PR), models 58, preprocessing 66. Tracked in #166.
+# Still to do (count at the time of writing): experimental 5 (open PR),
+# models 58, preprocessing 66. Tracked in #166.
 [[tool.mypy.overrides]]
 module = [
     "philanthropy.cli",
     "philanthropy.datasets.*",
     "philanthropy.inspection.*",
     "philanthropy.metrics.*",
+    "philanthropy.model_selection.*",
     "philanthropy.utils.*",
     "philanthropy.visualisation.*",
 ]


### PR DESCRIPTION
Part 2 of #166.

## What changed

`philanthropy.model_selection` (4 functions) annotated and added to the `[[tool.mypy.overrides]]`
list started in #167.

`split()` returns a generator; typed `Iterator[Tuple[np.ndarray, np.ndarray]]` to match its own
`Yields` docstring section rather than the plain-return `Tuple` pattern its `get_n_splits` neighbour
uses.

## The ratchet actually extends

```
$ printf '\n\ndef _probe(x):\n    return x\n' >> philanthropy/model_selection/_temporal_donor_splitter.py
$ python -m mypy philanthropy
philanthropy/model_selection/_temporal_donor_splitter.py:460: error: Function is missing a type annotation  [no-untyped-def]
$ git checkout philanthropy/model_selection/_temporal_donor_splitter.py
$ python -m mypy philanthropy
Success: no issues found in 50 source files
```

`experimental`, `cli`, `models` and `preprocessing` remain, tracked in #166.

## Verification

```
$ python -m mypy philanthropy
Success: no issues found in 50 source files
$ python -m flake8 philanthropy/model_selection
(clean)
$ python -m pytest --doctest-modules philanthropy/model_selection/_temporal_donor_splitter.py tests/test_model_selection.py -q
37 passed
```