### PR TITLE
fix: remove dead hasattr branch in WealthPercentileTransformer.fit (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- Removed dead `hasattr(X, "columns")` branch in `WealthPercentileTransformer.fit` since `validate_data` returns a NumPy array and sets `feature_names_in_` for DataFrame inputs (issue #168).
+
 ### Changed
 - README coverage badge now links to `pyproject.toml` and reads "≥92% floor"
   rather than a bare "≥92%". It was a static shields.io string with no tie to

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,6 +45,8 @@ contribution. Code, docs, tests, and review all count.
   single-class fallback coverage for
   `PlannedGivingIntentScorer.predict_intent_score`
   ([#149](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/149)).
+- [@HeaTTap](https://github.com/HeaTTap): removed dead `hasattr(X, "columns")` branch in `WealthPercentileTransformer.fit` and pinned feature-name handling for DataFrame and array inputs ([#168](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/168)).
+
 
 ## Getting listed
 

--- a/philanthropy/preprocessing/_wealth_percentile.py
+++ b/philanthropy/preprocessing/_wealth_percentile.py
@@ -42,11 +42,9 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         training distribution, not against the batch being transformed.
         """
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=True)
-        
-        if hasattr(X, "columns"):
-             self.feature_names_in_ = np.array(X.columns.tolist(), dtype=object)
-        elif not hasattr(self, "feature_names_in_"):
-             self.feature_names_in_ = np.array([f"x{i}" for i in range(X.shape[1])], dtype=object)
+        # validate_data sets feature_names_in_ when input is a DataFrame
+        if not hasattr(self, "feature_names_in_"):
+            self.feature_names_in_ = np.array([f"x{i}" for i in range(X.shape[1])], dtype=object)
 
         # Use feature_names_in_ to resolve columns
         if self.wealth_cols is not None:

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -31,6 +31,7 @@ from philanthropy.preprocessing import (
     CRMCleaner,
     EncounterTransformer,
     FiscalYearTransformer,
+    WealthPercentileTransformer,
     WealthScreeningImputer,
 )
 
@@ -723,3 +724,12 @@ class TestValidationReRaiseGuards:
         X = np.array([["2023-01-01", "1250.50"]], dtype=object)
         out = np.asarray(CRMCleaner().fit(X).transform(X))
         assert out.shape == (1, 2)
+
+
+def test_wealth_percentile_feature_names_match_for_frame_and_array_input():
+    df = pd.DataFrame({"net_worth": [1.0, 2.0, 3.0], "other": [1.0, 2.0, 3.0]})
+    a = WealthPercentileTransformer().fit(df)
+    b = WealthPercentileTransformer().fit(df.to_numpy())
+    assert list(a.get_feature_names_out()) == ["net_worth", "other", "net_worth_pct_rank"]
+    assert list(b.get_feature_names_out()) == ["x0", "x1"]
+


### PR DESCRIPTION
## What & why

Resolves #168

In WealthPercentileTransformer.fit, validate_data returns a NumPy array so hasattr(X, "columns") was never True and that branch never executed. The elif branch beneath it was handling both DataFrame and ndarray inputs.

This PR:
1. Deletes the dead hasattr(X, "columns") branch in WealthPercentileTransformer.fit and promotes the elif condition to a regular if statement with an explanatory comment.
2. Adds unit test test_wealth_percentile_feature_names_match_for_frame_and_array_input in tests/test_preprocessing.py verifying that get_feature_names_out preserves column names for DataFrame inputs and generates x0..xn for ndarray inputs.
3. Adds entry to CHANGELOG.md and CONTRIBUTORS.md.

## Checklist
- [x] `make ci` passes locally (lint -> collection -> tests -> coverage >= 92%)
- [x] New/changed public API has docstrings and is exported in the subpackage `__init__.py`
- [x] Tests added or updated
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Added yourself to `CONTRIBUTORS.md` (skip if you would rather not be listed)
