### PR TITLE
types: finish the mypy ratchet across experimental, models, and preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,18 +199,18 @@ entry is mid-deprecation.
   feature tables.
 
 ### Typing
-- **mypy ratchet started.** `py.typed` ships in the wheel, so a user's type
+- **mypy ratchet finished.** `py.typed` ships in the wheel, so a user's type
   checker treats every unannotated function here as `Any`, which is worse than
   shipping no type information: it silently disables checking at the boundary
-  instead of admitting there is nothing to check. `philanthropy.datasets`,
-  `.inspection`, `.metrics`, `.utils` and `.visualisation` are now fully
-  annotated and listed under a `[[tool.mypy.overrides]]` block with
-  `disallow_untyped_defs = true`, so a new unannotated function in any of them
-  fails CI rather than enlarging the backlog. `cli` and `model_selection` are
-  now annotated and listed too (`split`'s generator return is
-  `Iterator[Tuple[ndarray, ndarray]]`, matching its `Yields` docstring
-  section). `experimental` (open PR), `models` and `preprocessing` remain,
-  tracked in #166.
+  instead of admitting there is nothing to check. `experimental`, `models` and
+  `preprocessing`, the last three subpackages, are now fully annotated: `fit`
+  returns a per-class `TypeVar` bound to the class rather than a string
+  literal, so a subclass's `fit` no longer reports its parent's type;
+  `__sklearn_tags__` returns sklearn's public `Tags` dataclass
+  (`scikit-learn>=1.6`, the declared floor). With every subpackage covered,
+  the `[[tool.mypy.overrides]]` block is gone and `disallow_untyped_defs =
+  true` is a top-level `[tool.mypy]` setting, so a newly-added unannotated
+  function anywhere in `philanthropy` fails CI. Closes #166.
 - `ensure_local_path` is now generic in its argument (`TypeVar`) rather than
   declared `-> str`. It returns its input unchanged, and both call sites pass
   something that may be a `Path`, so the old annotation was a small lie; the

--- a/philanthropy/experimental/_uplift.py
+++ b/philanthropy/experimental/_uplift.py
@@ -10,10 +10,14 @@ this is why the estimator lives in the experimental package.
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="UpliftTLearner")
 
 
 class UpliftTLearner(ClassifierMixin, BaseEstimator):
@@ -85,7 +89,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
         self.max_depth = max_depth
         self.random_state = random_state
 
-    def fit(self, X, y, treatment) -> "UpliftTLearner":
+    def fit(self: _Self, X: Any, y: Any, treatment: Any) -> _Self:
         """Fit the two arm-specific models.
 
         Parameters
@@ -134,7 +138,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
         self.model_control_ = self._fit_arm(X[is_control], y[is_control])
         return self
 
-    def _fit_arm(self, X_arm, y_arm) -> RandomForestClassifier:
+    def _fit_arm(self, X_arm: Any, y_arm: Any) -> RandomForestClassifier:
         """Fit one arm's RandomForestClassifier."""
         model = RandomForestClassifier(
             n_estimators=self.n_estimators,
@@ -145,7 +149,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
         return model
 
     @staticmethod
-    def _prob_give(model: RandomForestClassifier, X) -> np.ndarray:
+    def _prob_give(model: RandomForestClassifier, X: Any) -> np.ndarray:
         """Return P(class == 1) from a fitted arm, guarding single-class arms.
 
         If the arm saw only one class during fit, ``predict_proba`` returns a
@@ -158,7 +162,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
             return np.full(proba.shape[0], 1.0 if 1 in model.classes_ else 0.0)
         return proba[:, 1]
 
-    def predict_uplift_score(self, X) -> np.ndarray:
+    def predict_uplift_score(self, X: Any) -> np.ndarray:
         """Return the estimated uplift for each donor.
 
         Parameters
@@ -184,7 +188,7 @@ class UpliftTLearner(ClassifierMixin, BaseEstimator):
         p_control = self._prob_give(self.model_control_, X)
         return p_treated - p_control
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Return 1 where soliciting is expected to help, else 0.
 
         Convenience wrapper: ``(predict_uplift_score(X) > 0).astype(int)``.

--- a/philanthropy/models/_ask.py
+++ b/philanthropy/models/_ask.py
@@ -41,12 +41,15 @@ True
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional, TypeVar
 
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="AskAmountRecommender")
 
 
 class AskAmountRecommender(RegressorMixin, BaseEstimator):
@@ -177,14 +180,14 @@ class AskAmountRecommender(RegressorMixin, BaseEstimator):
         self.random_state = random_state
         self.ask_floor = ask_floor
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.regressor_tags.poor_score = True
         return tags
 
     @property
-    def n_iter_(self):
+    def n_iter_(self) -> int:
         """Number of iterations run by the backend estimator."""
         check_is_fitted(self, ["estimator_"])
         return self.estimator_.n_iter_
@@ -193,7 +196,7 @@ class AskAmountRecommender(RegressorMixin, BaseEstimator):
     # Public API
     # ------------------------------------------------------------------
 
-    def fit(self, X, y) -> "AskAmountRecommender":
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Fit the ask-amount recommender to labelled prospect data."""
         X, y = validate_data(self, X, y, ensure_all_finite="allow-nan", reset=True)
         self.n_features_in_ = X.shape[1]
@@ -209,7 +212,7 @@ class AskAmountRecommender(RegressorMixin, BaseEstimator):
         self.estimator_.fit(X, y)
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict the base ask amount for each prospect."""
         check_is_fitted(self, ["estimator_"])
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
@@ -218,8 +221,8 @@ class AskAmountRecommender(RegressorMixin, BaseEstimator):
 
     def ask_ladder(
         self,
-        X,
-        multipliers=(1.0, 1.5, 2.5),
+        X: Any,
+        multipliers: Any = (1.0, 1.5, 2.5),
     ) -> np.ndarray:
         """Return a discrete gift array (ask ladder) for each prospect.
 

--- a/philanthropy/models/_conformal_interval.py
+++ b/philanthropy/models/_conformal_interval.py
@@ -110,14 +110,17 @@ import math
 from dataclasses import dataclass
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Optional, Union
+from typing import Any, Optional, TypeVar, Union
 
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.exceptions import NotFittedError
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 _SCORES = ("absolute", "difficulty", "log")
+_Self = TypeVar("_Self", bound="GiftIntervalCalibrator")
+_Alpha = Union[float, Fraction, Decimal, int]
 
 
 @dataclass(frozen=True)
@@ -147,7 +150,7 @@ class GiftInterval:
     requested_level: float
 
 
-def _exact_alpha(alpha) -> Fraction:
+def _exact_alpha(alpha: _Alpha) -> Fraction:
     """Read ``alpha`` as an exact rational.
 
     A ``float`` is read as the shortest decimal that round-trips to it, so
@@ -169,7 +172,7 @@ def _exact_alpha(alpha) -> Fraction:
     )
 
 
-def _min_calibration_size(alpha) -> int:
+def _min_calibration_size(alpha: _Alpha) -> int:
     """Smallest calibration set that certifies ``1 - alpha`` from one rank.
 
     ``ceil((n + 1) * (1 - alpha)) <= n`` reduces to ``n >= 1 / alpha - 1``, so
@@ -202,7 +205,7 @@ def _calibrate(scores: np.ndarray, alpha: Fraction, where: str = "") -> tuple:
     return float(np.sort(scores)[r - 1]), r
 
 
-def _key(value):
+def _key(value: Any) -> Any:
     """Hashable Python key for a group label that may be a numpy scalar."""
     return value.item() if isinstance(value, np.generic) else value
 
@@ -349,10 +352,10 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
 
     def __init__(
         self,
-        estimator,
-        alpha: Union[float, Fraction, Decimal, int] = 0.05,
+        estimator: Any,
+        alpha: _Alpha = 0.05,
         score: str = "absolute",
-        difficulty_estimator=None,
+        difficulty_estimator: Any = None,
         lower_bound: Optional[float] = 0.0,
     ) -> None:
         # scikit-learn rule: __init__ stores parameters and does NO logic.
@@ -362,7 +365,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
         self.difficulty_estimator = difficulty_estimator
         self.lower_bound = lower_bound
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.regressor_tags.poor_score = True
@@ -372,7 +375,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
     # Public API
     # ------------------------------------------------------------------
 
-    def fit(self, X, y, groups=None) -> "GiftIntervalCalibrator":
+    def fit(self: _Self, X: Any, y: Any, groups: Any = None) -> _Self:
         """Calibrate on held-out rows.
 
         Parameters
@@ -463,13 +466,13 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
             self.attained_level_[_key(k)] = float(Fraction(r, n_g + 1))
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Return ``estimator``'s point prediction, unchanged."""
         check_is_fitted(self, ["quantile_"])
         validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self._point(X, None)
 
-    def predict_gift_interval(self, X, groups=None) -> GiftInterval:
+    def predict_gift_interval(self, X: Any, groups: Any = None) -> GiftInterval:
         """Return a calibrated interval on the dollar amount for each row.
 
         Parameters
@@ -556,7 +559,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
                 f"amount; {type(self.estimator).__name__} does not."
             )
 
-    def _point(self, X, n: Optional[int]) -> np.ndarray:
+    def _point(self, X: Any, n: Optional[int]) -> np.ndarray:
         """Delegate to ``estimator``, passing X through untouched.
 
         ``validate_data`` has already checked the width; the original object
@@ -572,7 +575,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
             )
         return yhat
 
-    def _difficulty(self, X, n: int) -> np.ndarray:
+    def _difficulty(self, X: Any, n: int) -> np.ndarray:
         est = self.difficulty_estimator
         if est is None:
             raise ValueError(
@@ -595,7 +598,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
             )
         return sigma
 
-    def _conformity_scores(self, X, yhat: np.ndarray, y: np.ndarray) -> tuple:
+    def _conformity_scores(self, X: Any, yhat: np.ndarray, y: np.ndarray) -> tuple:
         if self.score == "absolute":
             return np.abs(y - yhat), None
         if self.score == "difficulty":
@@ -614,7 +617,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
                 'score="absolute" for a target that can go negative.'
             )
 
-    def _bounds(self, X, yhat: np.ndarray, q: np.ndarray) -> tuple:
+    def _bounds(self, X: Any, yhat: np.ndarray, q: np.ndarray) -> tuple:
         if self.score == "log":
             self._check_log_domain(yhat, None)
             base = np.log1p(yhat)
@@ -623,7 +626,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
         return yhat - half, yhat + half
 
     @staticmethod
-    def _group_labels(groups, n: int) -> np.ndarray:
+    def _group_labels(groups: Any, n: int) -> np.ndarray:
         labels = np.asarray(groups)
         if labels.ndim != 1:
             raise ValueError(
@@ -637,7 +640,7 @@ class GiftIntervalCalibrator(RegressorMixin, BaseEstimator):
         return labels
 
 
-def _n_rows(X) -> int:
+def _n_rows(X: Any) -> int:
     try:
         return int(X.shape[0])
     except AttributeError:

--- a/philanthropy/models/_forecast.py
+++ b/philanthropy/models/_forecast.py
@@ -37,7 +37,7 @@ produced, mirroring the contract of
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple, TypeVar
 
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
@@ -45,6 +45,8 @@ from sklearn.linear_model import LinearRegression
 from sklearn.neural_network import MLPRegressor
 from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="FinancialForecastModel")
 
 
 class FinancialForecastModel(RegressorMixin, BaseEstimator):
@@ -168,7 +170,7 @@ class FinancialForecastModel(RegressorMixin, BaseEstimator):
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _impute(self, X) -> np.ndarray:
+    def _impute(self, X: Any) -> np.ndarray:
         """Fill NaNs with the frozen per-column training medians.
 
         Casting to ``float64`` guarantees ``np.isnan`` works on integer inputs
@@ -208,7 +210,7 @@ class FinancialForecastModel(RegressorMixin, BaseEstimator):
     # Public API
     # ------------------------------------------------------------------
 
-    def fit(self, X, y) -> "FinancialForecastModel":
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Fit the hybrid forecaster on labelled revenue data.
 
         Parameters
@@ -267,7 +269,7 @@ class FinancialForecastModel(RegressorMixin, BaseEstimator):
         )
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict revenue for each period in ``X`` (cross-sectional hybrid).
 
         Parameters
@@ -289,7 +291,7 @@ class FinancialForecastModel(RegressorMixin, BaseEstimator):
             out = out + self.nonlinear_model_.predict(X_imp)
         return out
 
-    def predict_revenue_forecast(self, X, horizon: int) -> np.ndarray:
+    def predict_revenue_forecast(self, X: Any, horizon: int) -> np.ndarray:
         """Forecast giving revenue for the next ``horizon`` periods.
 
         The supplied ``X`` provides the most recent observed context: its hybrid

--- a/philanthropy/models/_lapse.py
+++ b/philanthropy/models/_lapse.py
@@ -6,11 +6,15 @@ Predictive model for donor lapse using RandomForestClassifier.
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils.validation import check_is_fitted, validate_data
 from sklearn.utils import Tags
+
+_Self = TypeVar("_Self", bound="LapsePredictor")
 
 
 class LapsePredictor(ClassifierMixin, BaseEstimator):
@@ -40,15 +44,15 @@ class LapsePredictor(ClassifierMixin, BaseEstimator):
         self,
         n_estimators: int = 100,
         max_depth: int | None = None,
-        class_weight=None,
+        class_weight: Any = None,
         random_state: int | None = None,
-    ):
+    ) -> None:
         self.n_estimators = n_estimators
         self.max_depth = max_depth
         self.class_weight = class_weight
         self.random_state = random_state
 
-    def fit(self, X, y) -> "LapsePredictor":
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Fit the LapsePredictor.
 
         Parameters
@@ -75,19 +79,19 @@ class LapsePredictor(ClassifierMixin, BaseEstimator):
         self.estimator_.fit(X, y)
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict binary lapse labels."""
         check_is_fitted(self)
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict(X)
 
-    def predict_proba(self, X) -> np.ndarray:
+    def predict_proba(self, X: Any) -> np.ndarray:
         """Return class probabilities of shape (n_samples, 2)."""
         check_is_fitted(self)
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict_proba(X)
 
-    def predict_lapse_score(self, X) -> np.ndarray:
+    def predict_lapse_score(self, X: Any) -> np.ndarray:
         """Return P(lapse) × 100 rounded to 2 decimal places (0–100 scale)."""
         check_is_fitted(self)
         proba = self.predict_proba(X)

--- a/philanthropy/models/_moves.py
+++ b/philanthropy/models/_moves.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 from sklearn.base import ClassifierMixin, BaseEstimator
 from sklearn.utils.validation import check_is_fitted, validate_data
@@ -8,6 +10,9 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.ensemble import HistGradientBoostingClassifier
 
 MOVES_STAGES = ["IDENTIFY", "QUALIFY", "CULTIVATE", "SOLICIT", "STEWARD"]
+
+_Self = TypeVar("_Self", bound="MovesManagementClassifier")
+
 
 class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
     """
@@ -20,13 +25,13 @@ class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
         max_iter: int = 200,
         class_weight: str | dict | None = "balanced",
         random_state: int | None = None,
-    ):
+    ) -> None:
         self.learning_rate = learning_rate
         self.max_iter = max_iter
         self.class_weight = class_weight
         self.random_state = random_state
 
-    def fit(self, X, y):
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Fit the classifier to labelled moves-stage data.
 
         Parameters
@@ -72,7 +77,7 @@ class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
         self.n_iter_ = self.estimator_.n_iter_
         return self
 
-    def predict(self, X):
+    def predict(self, X: Any) -> np.ndarray:
         """Predict the next moves-management stage for each donor.
 
         Parameters
@@ -95,7 +100,7 @@ class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
         y_pred = self.estimator_.predict(X)
         return self.label_encoder_.inverse_transform(y_pred)
 
-    def predict_proba(self, X):
+    def predict_proba(self, X: Any) -> np.ndarray:
         """Return class probabilities for each moves-management stage.
 
         Parameters
@@ -117,7 +122,7 @@ class MovesManagementClassifier(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict_proba(X)
 
-    def action_priority(self, X) -> dict:
+    def action_priority(self, X: Any) -> dict:
         """Predict the next-best stage per donor plus a portfolio rollup.
 
         Unlike ``predict``/``predict_proba`` (which return ndarrays), this

--- a/philanthropy/models/_planned_giving.py
+++ b/philanthropy/models/_planned_giving.py
@@ -6,11 +6,16 @@ Models for predicting planned giving (bequest) intent.
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.ensemble import GradientBoostingClassifier
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="PlannedGivingIntentScorer")
 
 
 class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
@@ -32,11 +37,11 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
         self,
         n_estimators: int = 100,
         random_state: int | None = None,
-    ):
+    ) -> None:
         self.n_estimators = n_estimators
         self.random_state = random_state
 
-    def fit(self, X, y) -> "PlannedGivingIntentScorer":
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Fit the calibrated classifier to planned-giving intent labels.
 
         Parameters
@@ -69,7 +74,7 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
         self.estimator_.fit(X, y)
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict bequest/planned-giving intent labels.
 
         Parameters
@@ -91,7 +96,7 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict(X)
 
-    def predict_proba(self, X) -> np.ndarray:
+    def predict_proba(self, X: Any) -> np.ndarray:
         """Return calibrated class probabilities.
 
         Parameters
@@ -113,7 +118,7 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict_proba(X)
 
-    def predict_intent_score(self, X) -> np.ndarray:
+    def predict_intent_score(self, X: Any) -> np.ndarray:
         """
         Return P(planned giving intent) × 100, rounded to 2 decimal places.
 
@@ -133,6 +138,6 @@ class PlannedGivingIntentScorer(ClassifierMixin, BaseEstimator):
             scores = np.round(proba[:, 1] * 100.0, 2)
         return scores
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         return tags

--- a/philanthropy/models/_propensity.py
+++ b/philanthropy/models/_propensity.py
@@ -10,7 +10,7 @@ score (0–100) for use by prospect-management officers and gift officers.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional, TypeVar
 
 import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
@@ -19,6 +19,9 @@ from sklearn.calibration import CalibratedClassifierCV
 from sklearn.utils import Tags
 from sklearn.utils.multiclass import unique_labels
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_SelfD = TypeVar("_SelfD", bound="DonorPropensityModel")
+_SelfM = TypeVar("_SelfM", bound="MajorGiftClassifier")
 
 
 class DonorPropensityModel(ClassifierMixin, BaseEstimator):
@@ -169,7 +172,7 @@ class DonorPropensityModel(ClassifierMixin, BaseEstimator):
         min_samples_split: int = 2,
         min_samples_leaf: int = 1,
         min_weight_fraction_leaf: float = 0.0,
-        class_weight=None,
+        class_weight: Any = None,
         random_state: Optional[int] = None,
     ) -> None:
         self.n_estimators = n_estimators
@@ -184,7 +187,7 @@ class DonorPropensityModel(ClassifierMixin, BaseEstimator):
     # Public API
     # ------------------------------------------------------------------
 
-    def fit(self, X, y):
+    def fit(self: _SelfD, X: Any, y: Any) -> _SelfD:
         """Fit the DonorPropensityModel to labelled donor data.
 
         Parameters
@@ -226,7 +229,7 @@ class DonorPropensityModel(ClassifierMixin, BaseEstimator):
 
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict binary major-donor labels for each prospect.
 
         Parameters
@@ -249,7 +252,7 @@ class DonorPropensityModel(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, reset=False)
         return self.estimator_.predict(X)
 
-    def predict_proba(self, X) -> np.ndarray:
+    def predict_proba(self, X: Any) -> np.ndarray:
         """Return class-probability estimates for each prospect.
 
         Parameters
@@ -365,12 +368,17 @@ class MajorGiftClassifier(ClassifierMixin, BaseEstimator):
         tags.classifier_tags.multi_class = True
         return tags
     
-    def __init__(self, max_iter=100, learning_rate=0.1, random_state=None):
+    def __init__(
+        self,
+        max_iter: int = 100,
+        learning_rate: float = 0.1,
+        random_state: Optional[int] = None,
+    ) -> None:
         self.max_iter = max_iter
         self.learning_rate = learning_rate
         self.random_state = random_state
 
-    def fit(self, X, y):
+    def fit(self: _SelfM, X: Any, y: Any) -> _SelfM:
         """Fit the classifier to labelled donor data.
 
         Parameters
@@ -405,7 +413,7 @@ class MajorGiftClassifier(ClassifierMixin, BaseEstimator):
         )
         return self
 
-    def predict(self, X):
+    def predict(self, X: Any) -> np.ndarray:
         """Predict binary major-donor labels.
 
         Parameters
@@ -427,7 +435,7 @@ class MajorGiftClassifier(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict(X)
 
-    def predict_proba(self, X):
+    def predict_proba(self, X: Any) -> np.ndarray:
         """Return calibrated class probabilities.
 
         Parameters
@@ -450,7 +458,7 @@ class MajorGiftClassifier(ClassifierMixin, BaseEstimator):
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
         return self.estimator_.predict_proba(X)
 
-    def predict_affinity_score(self, X):
+    def predict_affinity_score(self, X: Any) -> np.ndarray:
         """Map the calibrated major-donor probability to a 0-100 score.
 
         Parameters

--- a/philanthropy/models/_propensity_baseline.py
+++ b/philanthropy/models/_propensity_baseline.py
@@ -3,10 +3,17 @@ philanthropy.models._propensity_baseline
 ================================
 """
 
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
 import numpy as np
 from sklearn.base import ClassifierMixin, BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.multiclass import check_classification_targets, type_of_target
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="PropensityScorer")
 
 
 class PropensityScorer(ClassifierMixin, BaseEstimator):
@@ -38,10 +45,10 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         In :meth:`fit`, if ``y`` has more than two classes.
     """
 
-    def __init__(self, threshold: float = 0.5):
+    def __init__(self, threshold: float = 0.5) -> None:
         self.threshold = threshold
 
-    def fit(self, X, y):
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Validate input and record the target classes.
 
         Parameters
@@ -72,7 +79,7 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         self.classes_ = np.unique(y)
         return self
 
-    def predict(self, X):
+    def predict(self, X: Any) -> np.ndarray:
         """Predict binary labels using the constant probability baseline.
 
         Parameters
@@ -100,7 +107,7 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         idx = (proba > self.threshold).astype(int)
         return self.classes_[idx]
 
-    def predict_proba(self, X):
+    def predict_proba(self, X: Any) -> np.ndarray:
         """Return the constant probability baseline.
 
         Parameters
@@ -127,7 +134,7 @@ class PropensityScorer(ClassifierMixin, BaseEstimator):
         prob_pos = np.full(n, 0.5)
         return np.column_stack([1 - prob_pos, prob_pos])
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.classifier_tags.poor_score = True
         tags.classifier_tags.multi_class = False

--- a/philanthropy/models/_wallet.py
+++ b/philanthropy/models/_wallet.py
@@ -43,12 +43,15 @@ True
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional, TypeVar
 
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="ShareOfWalletRegressor")
 
 
 class ShareOfWalletRegressor(RegressorMixin, BaseEstimator):
@@ -183,14 +186,14 @@ class ShareOfWalletRegressor(RegressorMixin, BaseEstimator):
         self.random_state = random_state
         self.capacity_floor = capacity_floor
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.regressor_tags.poor_score = True
         return tags
 
     @property
-    def n_iter_(self):
+    def n_iter_(self) -> int:
         """Number of iterations run by the backend estimator."""
         check_is_fitted(self, ["estimator_"])
         return self.estimator_.n_iter_
@@ -199,7 +202,7 @@ class ShareOfWalletRegressor(RegressorMixin, BaseEstimator):
     # Public API
     # ------------------------------------------------------------------
 
-    def fit(self, X, y) -> "ShareOfWalletRegressor":
+    def fit(self: _Self, X: Any, y: Any) -> _Self:
         """Fit the share-of-wallet capacity model to labelled prospect data."""
         X, y = validate_data(self, X, y, ensure_all_finite="allow-nan", reset=True)
         self.n_features_in_ = X.shape[1]
@@ -215,7 +218,7 @@ class ShareOfWalletRegressor(RegressorMixin, BaseEstimator):
         self.estimator_.fit(X, y)
         return self
 
-    def predict(self, X) -> np.ndarray:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict philanthropic capacity for each prospect."""
         check_is_fitted(self, ["estimator_"])
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=False)
@@ -224,7 +227,7 @@ class ShareOfWalletRegressor(RegressorMixin, BaseEstimator):
 
     def capacity_ratio(
         self,
-        X,
+        X: Any,
         historical_giving: np.ndarray,
     ) -> np.ndarray:
         """Return the predicted capacity-to-historical-giving ratio.

--- a/philanthropy/preprocessing/__init__.py
+++ b/philanthropy/preprocessing/__init__.py
@@ -5,6 +5,8 @@ CRM data cleaning, Fiscal Year-aware feature engineering, and
 clinical-encounter feature engineering for medical philanthropy.
 """
 
+from typing import Any
+
 from ._transformers import FiscalYearTransformer, CRMCleaner
 from ._wealth import WealthScreeningImputer
 from ._encounters import EncounterTransformer
@@ -41,7 +43,7 @@ _DEPRECATED_ALIASES = {
 }
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     """Resolve deprecated aliases lazily, warning once per access (PEP 562).
 
     Kept as an alias rather than a subclass on purpose: a subclass would be a

--- a/philanthropy/preprocessing/_discharge_window.py
+++ b/philanthropy/preprocessing/_discharge_window.py
@@ -14,10 +14,15 @@ decays from the floor outwards rather than peaking at the window midpoint. See
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="DischargeToSolicitationWindowTransformer")
 
 
 class DischargeToSolicitationWindowTransformer(TransformerMixin, BaseEstimator):
@@ -79,7 +84,7 @@ class DischargeToSolicitationWindowTransformer(TransformerMixin, BaseEstimator):
         self.days_since_discharge_col = days_since_discharge_col
         self.window_shape = window_shape
 
-    def fit(self, X, y=None) -> "DischargeToSolicitationWindowTransformer":
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Fit the transformer (no-op, validates parameters).
 
         Parameters
@@ -106,7 +111,7 @@ class DischargeToSolicitationWindowTransformer(TransformerMixin, BaseEstimator):
         validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: Any, y: Any = None) -> np.ndarray:
         """Transform X to two columns: in_window, window_position_score.
 
         Parameters
@@ -168,7 +173,7 @@ class DischargeToSolicitationWindowTransformer(TransformerMixin, BaseEstimator):
 
         return np.column_stack([in_window, window_score])
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Get output feature names."""
         check_is_fitted(self)
         return np.array(
@@ -176,7 +181,7 @@ class DischargeToSolicitationWindowTransformer(TransformerMixin, BaseEstimator):
             dtype=object,
         )
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.input_tags.string = True

--- a/philanthropy/preprocessing/_encounter_recency.py
+++ b/philanthropy/preprocessing/_encounter_recency.py
@@ -38,15 +38,18 @@ Typical usage
 from __future__ import annotations
 
 import warnings
-from typing import Optional
+from typing import Any, Optional, TypeVar
 
 import numpy as np
 import pandas as pd
 from pandas.errors import OutOfBoundsTimedelta
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 from ..utils._validation import validate_fiscal_year_start
+
+_Self = TypeVar("_Self", bound="EncounterRecencyTransformer")
 
 
 class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
@@ -152,7 +155,7 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         self,
         date_col: str | list[str] = "last_encounter_date",
         fiscal_year_start: int = 7,
-        reference_date=None,
+        reference_date: Any = None,
         timezone: Optional[str] = None,
     ) -> None:
         # scikit-learn rule: __init__ ONLY assigns; no validation, no side-effects.
@@ -246,7 +249,7 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         return pd.DataFrame(cols)
 
     @staticmethod
-    def _days_since_day_resolution(ref_ts, dates: pd.Series) -> pd.Series:
+    def _days_since_day_resolution(ref_ts: Any, dates: pd.Series) -> pd.Series:
         """Overflow-safe ``days_since`` for extreme date spans (>~292 years).
 
         Differences at day resolution so the delta stays inside int64; ``NaT``
@@ -268,7 +271,7 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
     # fit / transform
     # ------------------------------------------------------------------
 
-    def fit(self, X, y=None) -> "EncounterRecencyTransformer":
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Validate parameters and freeze the reference date from training data.
 
         Parameters
@@ -322,7 +325,7 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
 
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: Any, y: Any = None) -> np.ndarray:
         """Compute encounter recency features.
 
         Parameters
@@ -384,7 +387,7 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         out_df = pd.concat(parts, axis=1) if parts else pd.DataFrame()
         return out_df.to_numpy(dtype=np.float64)
 
-    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return output feature names.
 
         Returns
@@ -404,7 +407,7 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
             ]
         return np.array(names, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.input_tags.string = True  # Date columns are string-like on entry

--- a/philanthropy/preprocessing/_encounters.py
+++ b/philanthropy/preprocessing/_encounters.py
@@ -43,12 +43,15 @@ EncounterTransformer(...)
 from __future__ import annotations
 
 import warnings
-from typing import List
+from typing import Any, List, TypeVar
 
 import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="EncounterTransformer")
 
 
 # ---------------------------------------------------------------------------
@@ -56,7 +59,9 @@ from sklearn.utils.validation import check_is_fitted, validate_data
 # ---------------------------------------------------------------------------
 
 
-def _apply_as_of_cutoff(enc, discharge_col, as_of, class_name):
+def _apply_as_of_cutoff(
+    enc: pd.DataFrame, discharge_col: str, as_of: Any, class_name: str
+) -> pd.DataFrame:
     """Drop encounter rows discharged after ``as_of``.
 
     Returns ``enc`` unchanged when ``as_of`` is ``None``. Rows whose discharge
@@ -86,7 +91,9 @@ def _apply_as_of_cutoff(enc, discharge_col, as_of, class_name):
     return enc[keep]
 
 
-def _warn_if_unbounded(enc, discharge_col, gift_dates, class_name):
+def _warn_if_unbounded(
+    enc: pd.DataFrame, discharge_col: str, gift_dates: Any, class_name: str
+) -> None:
     """Warn when ``as_of`` is unset and the encounter table runs past the gifts.
 
     The default ``as_of=None`` aggregates the whole encounter table, which is
@@ -258,8 +265,8 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         allow_negative_days: bool = False,
         id_cols_to_drop: list[str] | None = None,
         pii_patterns: tuple[str, ...] | None = None,
-        as_of=None,
-    ):
+        as_of: Any = None,
+    ) -> None:
         self.encounter_df = encounter_df
         self.encounter_path = encounter_path
         self.discharge_col = discharge_col
@@ -270,7 +277,7 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         self.pii_patterns = pii_patterns
         self.as_of = as_of
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         """Drop the raw encounter table from pickles and joblib bundles.
 
         ``transform`` reads only ``encounter_summary_``, the per-donor aggregate
@@ -356,7 +363,7 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
     # fit / transform
     # ------------------------------------------------------------------
 
-    def fit(self, X: pd.DataFrame, y=None) -> "EncounterTransformer":
+    def fit(self: _Self, X: pd.DataFrame, y: Any = None) -> _Self:
         """Compute per-donor encounter summaries from ``encounter_df``.
 
         The fitted artefact ``encounter_summary_`` is a lightweight per-donor
@@ -548,7 +555,7 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         # Convert back to numpy array float64 as instructed
         return X_out.to_numpy(dtype=np.float64)
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return privacy-filtered donor and generated encounter feature names.
 
         Parameters
@@ -578,6 +585,6 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         out.extend(["days_since_last_discharge", "encounter_frequency_score"])
         return np.array(out, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         return tags

--- a/philanthropy/preprocessing/_grateful_patient.py
+++ b/philanthropy/preprocessing/_grateful_patient.py
@@ -13,13 +13,17 @@ from __future__ import annotations
 
 import re
 import warnings
+from typing import Any, TypeVar
 
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
 
 from ._encounters import _apply_as_of_cutoff
+
+_Self = TypeVar("_Self", bound="GratefulPatientFeaturizer")
 
 # Illustrative default service-line capacity weights. These numbers have NO
 # published source: they encode the common practitioner expectation that
@@ -168,7 +172,7 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
         capacity_weights: dict[str, float] | None = None,
         merge_key: str = "donor_id",
         discharge_col: str = "discharge_date",
-        as_of=None,
+        as_of: Any = None,
     ) -> None:
         self.encounter_df = encounter_df
         self.encounter_path = encounter_path
@@ -181,7 +185,7 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
         self.discharge_col = discharge_col
         self.as_of = as_of
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         """Drop the raw encounter table from pickles and joblib bundles.
 
         ``transform`` reads only ``encounter_summary_``, the per-donor aggregate
@@ -205,7 +209,7 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
         state["encounter_df"] = None
         return state
 
-    def fit(self, X, y=None) -> "GratefulPatientFeaturizer":
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Build per-donor encounter summaries from encounter data.
 
         Parameters
@@ -351,7 +355,7 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
 
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: Any, y: Any = None) -> np.ndarray:
         """Merge clinical features into the donor feature matrix.
 
         Parameters
@@ -430,7 +434,7 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
 
         return result.to_numpy(dtype=np.float64)
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the generated grateful-patient feature names.
 
         Parameters
@@ -460,7 +464,7 @@ class GratefulPatientFeaturizer(TransformerMixin, BaseEstimator):
             dtype=object,
         )
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags

--- a/philanthropy/preprocessing/_matching_gift.py
+++ b/philanthropy/preprocessing/_matching_gift.py
@@ -12,13 +12,18 @@ prioritisation model can weight prospects with employer-match upside.
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted
 
+_Self = TypeVar("_Self", bound="MatchingGiftFeaturizer")
 
-def _normalise_employer(val) -> str:
+
+def _normalise_employer(val: Any) -> str:
     """Return a lookup key for an employer cell.
 
     Null cells and whitespace-only strings normalise to the empty string,
@@ -122,7 +127,7 @@ class MatchingGiftFeaturizer(TransformerMixin, BaseEstimator):
         if missing:
             raise ValueError(f"X is missing required columns: {missing}")
 
-    def fit(self, X, y=None) -> "MatchingGiftFeaturizer":
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Register the input schema and freeze the match-ratio lookup.
 
         Parameters
@@ -159,7 +164,7 @@ class MatchingGiftFeaturizer(TransformerMixin, BaseEstimator):
         }
         return self
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: Any) -> np.ndarray:
         """Emit matching-gift features for each row of ``X``.
 
         Parameters
@@ -203,7 +208,7 @@ class MatchingGiftFeaturizer(TransformerMixin, BaseEstimator):
             np.float64
         )
 
-    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the generated matching-gift feature names.
 
         Parameters
@@ -228,7 +233,7 @@ class MatchingGiftFeaturizer(TransformerMixin, BaseEstimator):
             dtype=object,
         )
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags

--- a/philanthropy/preprocessing/_planned_giving.py
+++ b/philanthropy/preprocessing/_planned_giving.py
@@ -12,10 +12,15 @@ bequest/legacy gift intent classifiers.
 
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="PlannedGivingSignalTransformer")
 
 
 class PlannedGivingSignalTransformer(TransformerMixin, BaseEstimator):
@@ -98,7 +103,7 @@ class PlannedGivingSignalTransformer(TransformerMixin, BaseEstimator):
         self.age_threshold = age_threshold
         self.tenure_threshold_years = tenure_threshold_years
 
-    def fit(self, X, y=None) -> "PlannedGivingSignalTransformer":
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Validate input schema and record n_features_in_.
 
         Parameters
@@ -114,7 +119,7 @@ class PlannedGivingSignalTransformer(TransformerMixin, BaseEstimator):
         validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: Any, y: Any = None) -> np.ndarray:
         """Compute the 4-column planned-giving feature vector.
 
         Parameters
@@ -192,7 +197,7 @@ class PlannedGivingSignalTransformer(TransformerMixin, BaseEstimator):
             ]
         )
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the generated planned-giving signal names.
 
         Parameters
@@ -217,7 +222,7 @@ class PlannedGivingSignalTransformer(TransformerMixin, BaseEstimator):
             dtype=object,
         )
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         # This transformer extracts named columns from mixed-type DataFrames

--- a/philanthropy/preprocessing/_rfm.py
+++ b/philanthropy/preprocessing/_rfm.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
 import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted
+
+_Self = TypeVar("_Self", bound="RFMTransformer")
+
 
 class RFMTransformer(TransformerMixin, BaseEstimator):
     """
@@ -33,12 +41,17 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
         the output shape does not change under existing callers, and will become
         the default in the next major release.
     """
-    def __init__(self, reference_date=None, agg_func='sum', include_tenure=False):
+    def __init__(
+        self,
+        reference_date: Any = None,
+        agg_func: Any = 'sum',
+        include_tenure: bool = False,
+    ) -> None:
         self.reference_date = reference_date
         self.agg_func = agg_func
         self.include_tenure = include_tenure
 
-    def fit(self, X, y=None):
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """
         Fits the transformer. This simply validates the input and returns self.
         """
@@ -65,7 +78,7 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
             self.reference_date_ = pd.to_datetime(X_df["gift_date"]).max()
         return self
 
-    def transform(self, X):
+    def transform(self, X: Any) -> pd.DataFrame:
         """
         Transforms the transaction logs into RFM features.
         """
@@ -110,13 +123,13 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
 
         return rfm_df
         
-    def _validate_input(self, X):
+    def _validate_input(self, X: Any) -> None:
         cols = X.columns if hasattr(X, "columns") else self.feature_names_in_
         required_cols = {"donor_id", "gift_date", "gift_amount"}
         if not required_cols.issubset(cols):
             raise ValueError(f"X must contain columns: {required_cols}")
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the donor identifier and generated RFM feature names.
 
         Parameters
@@ -142,7 +155,7 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
             names.append('tenure')
         return np.array(names, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.input_tags.string = True

--- a/philanthropy/preprocessing/_share_of_wallet.py
+++ b/philanthropy/preprocessing/_share_of_wallet.py
@@ -38,12 +38,16 @@ True
 from __future__ import annotations
 
 import warnings
-from typing import Optional, Literal
+from typing import Any, Optional, Literal, TypeVar
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.impute import KNNImputer
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_SelfK = TypeVar("_SelfK", bound="WealthScreeningImputerKNN")
+_SelfS = TypeVar("_SelfS", bound="ShareOfWalletScorer")
 
 
 # ---------------------------------------------------------------------------
@@ -179,7 +183,7 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
         return [c for c in input_cols
                 if any(sub in c.lower() for sub in self._CANONICAL_SUBSTRINGS)]
 
-    def fit(self, X, y=None) -> "WealthScreeningImputerKNN":
+    def fit(self: _SelfK, X: Any, y: Any = None) -> _SelfK:
         """Learn fill statistics or fit the KNN imputer from training data.
 
         Parameters
@@ -305,7 +309,7 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
         self._col_indices_ = col_indices
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: Any, y: Any = None) -> np.ndarray:
         """Apply imputation and optionally append missingness indicators.
 
         Parameters
@@ -379,7 +383,7 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
             return np.hstack([X_out] + indicators)
         return X_out
 
-    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return imputed feature names and optional missingness indicators.
 
         Parameters
@@ -414,7 +418,7 @@ class WealthScreeningImputerKNN(TransformerMixin, BaseEstimator):
                     out.append(f"{col}__was_missing")
         return np.array(out, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags
@@ -541,7 +545,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         self.major_tier_threshold = major_tier_threshold
         self.principal_tier_threshold = principal_tier_threshold
 
-    def fit(self, X, y=None) -> "ShareOfWalletScorer":
+    def fit(self: _SelfS, X: Any, y: Any = None) -> _SelfS:
         """Fit the scorer: record wealth scale from training data.
 
         Parameters
@@ -579,7 +583,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
 
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: Any, y: Any = None) -> np.ndarray:
         """Compute SoW score and numeric capacity tier.
 
         Parameters
@@ -639,7 +643,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
 
         return np.column_stack([sow, tiers])
 
-    def get_feature_names_out(self, input_features=None) -> np.ndarray:
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the capacity-utilisation ratio and encoded tier names.
 
         Parameters
@@ -694,7 +698,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         )
         return np.array(["sow_score", "capacity_tier"], dtype=object)
 
-    def get_tier_labels(self, X) -> np.ndarray:
+    def get_tier_labels(self, X: Any) -> np.ndarray:
         """Return human-readable tier labels for each row.
 
         Parameters
@@ -710,7 +714,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         tier_ints = out[:, 1].astype(int)
         return np.array([self.TIER_LABELS[t] for t in tier_ints], dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -15,7 +15,7 @@ fiscal-calendar start month.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeVar
 
 import warnings
 
@@ -23,8 +23,12 @@ import numpy as np
 import pandas as pd
 
 from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
 from philanthropy.utils._validation import validate_fiscal_year_start
+
+_SelfC = TypeVar("_SelfC", bound="CRMCleaner")
+_SelfF = TypeVar("_SelfF", bound="FiscalYearTransformer")
 
 
 def _get_pandas_output(estimator: Any) -> bool:
@@ -136,7 +140,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         self.amount_col = amount_col
         self.fiscal_year_start = fiscal_year_start
 
-    def fit(self, X, y=None) -> "CRMCleaner":
+    def fit(self: _SelfC, X: Any, y: Any = None) -> _SelfC:
         """Validate configuration and input without learning state.
 
         Parameters
@@ -172,7 +176,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         
         return self
 
-    def transform(self, X) -> np.ndarray | pd.DataFrame:
+    def transform(self, X: Any) -> np.ndarray | pd.DataFrame:
         """Clean CRM dates and amounts using the fitted column configuration.
 
         Parameters
@@ -217,7 +221,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
             return X_df
         return X_df.to_numpy()
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the CRM columns learned during fitting.
 
         Parameters
@@ -240,7 +244,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         names = list(self.feature_names_in_)
         return np.array(names, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.input_tags.string = True
@@ -258,11 +262,11 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
     or a :class:`~sklearn.pipeline.FeatureUnion`.
     """
 
-    def __init__(self, date_col: str = "gift_date", fiscal_year_start: int = 7):
+    def __init__(self, date_col: str = "gift_date", fiscal_year_start: int = 7) -> None:
         self.date_col = date_col
         self.fiscal_year_start = fiscal_year_start
 
-    def fit(self, X, y=None) -> "FiscalYearTransformer":
+    def fit(self: _SelfF, X: Any, y: Any = None) -> _SelfF:
         """Validate configuration and input without learning state.
 
         Parameters
@@ -295,7 +299,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
             raise ValueError("Complex data not supported")
         return self
 
-    def transform(self, X) -> np.ndarray | pd.DataFrame:
+    def transform(self, X: Any) -> np.ndarray | pd.DataFrame:
         """Return the fiscal year and quarter derived from ``date_col``.
 
         Parameters
@@ -355,7 +359,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
             return out_df
         return out_df.to_numpy()
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return the two generated fiscal-period feature names.
 
         Parameters
@@ -376,7 +380,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
         return np.array(["fiscal_year", "fiscal_quarter"], dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         tags.input_tags.string = True

--- a/philanthropy/preprocessing/_wealth.py
+++ b/philanthropy/preprocessing/_wealth.py
@@ -36,11 +36,14 @@ WealthScreeningImputer(...)
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional, TypeVar
 
 import numpy as np
 from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="WealthScreeningImputer")
 
 # Default column names used by common wealth-screening vendors
 _DEFAULT_WEALTH_COLS: List[str] = [
@@ -181,7 +184,7 @@ class WealthScreeningImputer(TransformerMixin, BaseEstimator):
     # fit / transform
     # ------------------------------------------------------------------
 
-    def fit(self, X, y=None) -> "WealthScreeningImputer":
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Learn fill statistics from training data.
 
         Parameters
@@ -249,7 +252,7 @@ class WealthScreeningImputer(TransformerMixin, BaseEstimator):
 
         return self
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: Any) -> np.ndarray:
         """Apply imputation with frozen fill values.
 
         Parameters
@@ -307,7 +310,7 @@ class WealthScreeningImputer(TransformerMixin, BaseEstimator):
             return np.hstack([X_out] + indicators)
         return X_out
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return imputed feature names and optional missingness indicators.
 
         Parameters
@@ -341,7 +344,7 @@ class WealthScreeningImputer(TransformerMixin, BaseEstimator):
                     out.append(f"{col}__was_missing")
         return np.array(out, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags

--- a/philanthropy/preprocessing/_wealth_percentile.py
+++ b/philanthropy/preprocessing/_wealth_percentile.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from typing import Any, TypeVar
+
 import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin, BaseEstimator
+from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
+
+_Self = TypeVar("_Self", bound="WealthPercentileTransformer")
 
 
 class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
@@ -19,7 +24,7 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         self.wealth_cols = wealth_cols
         self.output_suffix = output_suffix
 
-    def fit(self, X, y=None):
+    def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """Learn the training wealth distribution.
 
         Parameters
@@ -70,7 +75,7 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
 
         return self
 
-    def transform(self, X):
+    def transform(self, X: Any) -> np.ndarray:
         """Rank features against the fitted training distribution.
 
         Parameters
@@ -115,7 +120,7 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         X_final = X_out.select_dtypes(include=[np.number])
         return X_final.to_numpy(dtype=np.float64)
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
         """Return input names followed by generated wealth-percentile names.
 
         Parameters
@@ -141,7 +146,7 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
                 out.append(f"{col}{self.output_suffix}")
         return np.array(out, dtype=object)
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         tags = super().__sklearn_tags__()
         tags.input_tags.allow_nan = True
         return tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,25 +102,6 @@ addopts = "--import-mode=importlib"
 [tool.mypy]
 files = ["philanthropy"]
 ignore_missing_imports = true
-
-# Ratchet, not a wish. `disallow_untyped_defs` is switched on one subpackage at
-# a time as its functions get annotated, so a newly-added unannotated function
-# in a listed subpackage fails CI instead of quietly enlarging the backlog.
-# Add a module to this list in the same PR that annotates it; when every
-# subpackage is listed, delete the override and set the flag at the top level.
-#
-# Still to do (count at the time of writing): experimental 5 (open PR),
-# models 58, preprocessing 66. Tracked in #166.
-[[tool.mypy.overrides]]
-module = [
-    "philanthropy.cli",
-    "philanthropy.datasets.*",
-    "philanthropy.inspection.*",
-    "philanthropy.metrics.*",
-    "philanthropy.model_selection.*",
-    "philanthropy.utils.*",
-    "philanthropy.visualisation.*",
-]
 disallow_untyped_defs = true
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- Annotates the last 129 unannotated functions in `philanthropy.experimental`, `philanthropy.models`, and `philanthropy.preprocessing`, the three subpackages issue #166 tracked as remaining.
- `fit` returns a per-class `TypeVar` bound to the class instead of a string-literal forward ref, so a subclass's `fit` no longer reports its parent's type. `__sklearn_tags__` returns sklearn's public `Tags` dataclass (`scikit-learn>=1.6`, the declared floor).
- With every subpackage covered, collapses `[[tool.mypy.overrides]]` into a top-level `disallow_untyped_defs = true` in `pyproject.toml`. Closes #166.
- CHANGELOG `### Typing` entry updated in place (matching the pattern from #167/#172/#173) rather than appended, since it's the same ongoing item reaching completion.

No behavior change: every edit is a type annotation. Verified with `make ci`, `make riskcov`, and the ratchet probe from #166 (appending an unannotated function now fails `mypy`, confirmed then reverted).

This PR only covers the mypy-ratchet item. A pass over `plan.md` (gitignored, not part of this diff) found that the rest of the JOSS-prep checklist's code-shaped items — `make_donor_panel`, the three CI-executed notebooks, the real-data docs page, the "which estimator" table, YAML issue forms, the coverage-badge link, `pypi-smoke.yml` — were already shipped in earlier PRs (#161, #162, #165, #167, #170, #172, #173). This is genuinely the last code-only item left in that list; everything else remaining is non-code (preprint, Discussion post, outreach).

## Test plan
- [x] `python -m mypy philanthropy` — success, no issues, 50 source files
- [x] Ratchet probe from #166: an unannotated function appended anywhere in `philanthropy` fails `mypy` with `disallow_untyped_defs`; reverted after confirming
- [x] `make ci` (flake8, mypy, doctests, full test suite) — green
- [x] `make riskcov` — 97% branch coverage over the risk-tier subtree, above the 93% floor