### PR TITLE
fix: reject missing wealth columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Changed
+- `WealthPercentileTransformer.fit` now raises an actionable `ValueError` when
+  an explicit `wealth_cols` list matches no training column; partial matches
+  and automatic detection remain unchanged.
 - README coverage badge now links to `pyproject.toml` and reads "≥92% floor"
   rather than a bare "≥92%". It was a static shields.io string with no tie to
   the enforced number, so it would have silently lied had `fail_under` ever

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,10 @@ contribution. Code, docs, tests, and review all count.
   unit-test coverage for `WealthPercentileTransformer`'s all-missing and
   partially-missing column branches in `WealthPercentileTransformer` (closes
   [#169](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/169)).
+- [@be-student](https://github.com/be-student): made explicit wealth-column
+  schema mismatches fail with actionable diagnostics and preserved automatic
+  and partial-match behavior (closes
+  [#156](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/156)).
 
 ## Getting listed
 

--- a/philanthropy/preprocessing/_wealth_percentile.py
+++ b/philanthropy/preprocessing/_wealth_percentile.py
@@ -7,8 +7,16 @@ from sklearn.utils.validation import check_is_fitted, validate_data
 
 
 class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
-    """
-    Computes wealth percentile ranks.
+    """Compute wealth percentile ranks.
+
+    Parameters
+    ----------
+    wealth_cols : list of str or None, default=None
+        Explicit wealth columns to rank. If none of the requested columns are
+        present during :meth:`fit`, a ``ValueError`` is raised. ``None`` keeps
+        automatic name-based detection, where finding no wealth columns is valid.
+    output_suffix : str, default="_pct_rank"
+        Suffix appended to generated percentile columns.
     """
 
     def __init__(
@@ -35,6 +43,12 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
             Fitted transformer. Freezes ``feature_names_in_``,
             ``imputed_cols_``, and ``percentile_lookup_``.
 
+        Raises
+        ------
+        ValueError
+            If ``wealth_cols`` was provided and none of those columns exist in
+            the training data.
+
         Notes
         -----
         ``percentile_lookup_`` stores the sorted training values per wealth
@@ -43,14 +57,17 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         """
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=True)
         
-        if hasattr(X, "columns"):
-             self.feature_names_in_ = np.array(X.columns.tolist(), dtype=object)
-        elif not hasattr(self, "feature_names_in_"):
-             self.feature_names_in_ = np.array([f"x{i}" for i in range(X.shape[1])], dtype=object)
+        if not hasattr(self, "feature_names_in_"):
+            self.feature_names_in_ = np.array([f"x{i}" for i in range(X.shape[1])], dtype=object)
 
         # Use feature_names_in_ to resolve columns
         if self.wealth_cols is not None:
             self.imputed_cols_ = [c for c in self.wealth_cols if c in self.feature_names_in_]
+            if not self.imputed_cols_:
+                raise ValueError(
+                    "none of the requested wealth_cols are present; "
+                    f"requested={self.wealth_cols!r}, available={list(self.feature_names_in_)!r}"
+                )
         else:
             targets = ("net_worth", "real_estate", "stock", "capacity")
             self.imputed_cols_ = [c for c in self.feature_names_in_ if any(t in str(c) for t in targets)]
@@ -63,10 +80,6 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
             s = pd.to_numeric(pd.Series(X[:, col_idx]), errors="coerce")
             valid_vals = s.dropna().to_numpy()
             self.percentile_lookup_[col] = np.sort(valid_vals)
-
-        if len(self.imputed_cols_) == 0 and self.wealth_cols is not None:
-             # If we expected columns but found none, we should probably warn or raise
-             pass
 
         return self
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -790,3 +790,22 @@ class TestWealthPercentileTransformer:
         assert not pd.isna(out.loc[4, "net_worth_pct_rank"])
         # Other column passes through unchanged
         assert out["other"].tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    def test_unknown_explicit_wealth_columns_are_loud(self):
+        df = pd.DataFrame({"net_worth": [100.0], "other": [1.0]})
+        with pytest.raises(ValueError, match=r"estimated_networth.*net_worth.*other"):
+            WealthPercentileTransformer(wealth_cols=["estimated_networth"]).fit(df)
+
+    def test_partial_explicit_wealth_column_match_still_fits(self):
+        df = pd.DataFrame({"net_worth": [100.0, 200.0], "other": [1.0, 2.0]})
+        transformer = WealthPercentileTransformer(
+            wealth_cols=["net_worth", "estimated_networth"]
+        ).fit(df)
+        assert transformer.imputed_cols_ == ["net_worth"]
+
+    def test_feature_names_are_preserved_or_generated(self):
+        df = pd.DataFrame({"net_worth": [100.0], "other": [1.0]})
+        from_frame = WealthPercentileTransformer().fit(df)
+        from_array = WealthPercentileTransformer().fit(df.to_numpy())
+        assert from_frame.feature_names_in_.tolist() == ["net_worth", "other"]
+        assert from_array.feature_names_in_.tolist() == ["x0", "x1"]


### PR DESCRIPTION
## What changed

An explicit `wealth_cols` list that matches no training column now raises an actionable `ValueError` naming requested and available columns. Partial matches and automatic detection remain valid. The dead post-validation DataFrame branch is removed, with feature-name behavior covered for frames and arrays.

## Validation

- focused WealthPercentileTransformer tests: 5 passed
- `make ci`: 1,951 passed, 25 skipped, 97.53% coverage
- mandatory pre-push hook: 1,951 passed, 25 skipped

Closes #156
