### PR TITLE
fix: accept parsed gift dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   wheel and turn this into a second working-tree test. Windows is included
   because the main matrix is Linux plus macOS.
 ### Fixed
+- `EncounterTransformer` now accepts parsed `datetime64` gift dates alongside
+  date strings, and reports unparseable values with the configured gift-date
+  column name instead of exposing NumPy's mixed-dtype promotion error. Closes
+  #163.
 - `CRMCleaner.transform` no longer silently corrupts complex amounts into
   wrong finite floats: cells holding actual `complex` values are masked to
   NaN with a `UserWarning` naming them, and a column where nothing parses

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,9 @@ contribution. Code, docs, tests, and review all count.
   unit-test coverage for `WealthPercentileTransformer`'s all-missing and
   partially-missing column branches in `WealthPercentileTransformer` (closes
   [#169](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/169)).
+- [@be-student](https://github.com/be-student): made `EncounterTransformer`
+  accept parsed gift dates and report invalid dates with a column-specific
+  error (closes [#163](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/163)).
 
 ## Getting listed
 

--- a/philanthropy/preprocessing/_encounters.py
+++ b/philanthropy/preprocessing/_encounters.py
@@ -338,6 +338,18 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
                     f"the `{label}` parameter in EncounterTransformer."
                 )
 
+    def _parse_gift_dates(self, X: pd.DataFrame) -> pd.Series:
+        """Return parsed gift dates or raise a column-specific error."""
+        values = X[self.gift_date_col]
+        parsed = pd.to_datetime(values, errors="coerce")
+        invalid = values.notna() & parsed.isna()
+        if invalid.any():
+            raise ValueError(
+                f"Column {self.gift_date_col!r} must contain date-like values; "
+                f"could not parse {int(invalid.sum())} non-missing value(s)."
+            )
+        return parsed
+
 
     # ------------------------------------------------------------------
     # Column-drop utilities
@@ -418,10 +430,13 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
 
         self._validate_X(X)
         gift_dates = (
-            pd.to_datetime(X[self.gift_date_col], errors="coerce")
+            self._parse_gift_dates(X)
             if isinstance(X, pd.DataFrame) and self.gift_date_col in X.columns
             else None
         )
+        if gift_dates is not None:
+            X = X.copy()
+            X[self.gift_date_col] = gift_dates.astype(object)
         X = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
         self.n_features_in_ = X.shape[1]
 
@@ -500,6 +515,10 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         
         if hasattr(X, "columns"):
             input_cols = list(X.columns)
+            self._validate_X(X)
+            gift_dates = self._parse_gift_dates(X)
+            X = X.copy()
+            X[self.gift_date_col] = gift_dates.astype(object)
         else:
             n_cols = np.shape(X)[1] if len(np.shape(X)) > 1 else 1
             input_cols = [f"x{i}" for i in range(n_cols)]
@@ -508,9 +527,7 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
         X_out = pd.DataFrame(X, columns=input_cols)
         
         self._validate_X(X_out)
-        X_out[self.gift_date_col] = pd.to_datetime(
-            X_out[self.gift_date_col], errors="coerce"
-        )
+        X_out[self.gift_date_col] = self._parse_gift_dates(X_out)
 
         # --- Merge the encounter summary ---
         X_out = X_out.merge(

--- a/tests/test_donor_panel.py
+++ b/tests/test_donor_panel.py
@@ -220,11 +220,6 @@ def test_encounters_feed_the_encounter_transformer_with_an_as_of_cutoff():
     )
     gifts = panel["gifts"][["donor_id", "gift_date", "gift_amount"]].copy()
     cutoff = gifts["gift_date"].max()
-    # Dates as strings, exactly as EncounterTransformer's own documented
-    # example passes them. A real datetime64 column raises DTypePromotionError
-    # inside sklearn's validation; that is a wart in the transformer, not in
-    # this generator, and it is tracked separately.
-    gifts["gift_date"] = gifts["gift_date"].dt.strftime("%Y-%m-%d")
 
     transformer = EncounterTransformer(
         encounter_df=panel["encounters"],

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -316,6 +316,39 @@ class TestEncounterTransformer:
         assert "days_since_last_discharge" in out.columns
         assert "encounter_frequency_score" in out.columns
 
+    def test_string_and_datetime_gift_dates_produce_equal_output(
+        self, encounter_df, gift_df_with_ids
+    ):
+        parsed_gifts = gift_df_with_ids.assign(
+            gift_date=pd.to_datetime(gift_df_with_ids["gift_date"])
+        )
+
+        string_out = EncounterTransformer(
+            encounter_df=encounter_df, as_of="2023-06-01"
+        ).set_output(transform="pandas").fit_transform(gift_df_with_ids)
+        parsed_out = EncounterTransformer(
+            encounter_df=encounter_df, as_of=pd.Timestamp("2023-06-01")
+        ).set_output(transform="pandas").fit_transform(parsed_gifts)
+
+        pd.testing.assert_frame_equal(parsed_out, string_out)
+
+    @pytest.mark.parametrize("phase", ["fit", "transform"])
+    def test_unparseable_gift_date_names_column(self, phase):
+        encounters = pd.DataFrame(
+            {"donor_id": [1], "discharge_date": ["2022-01-01"]}
+        )
+        valid = pd.DataFrame(
+            {"donor_id": [1], "gift_date": ["2023-01-01"], "gift_amount": [1.0]}
+        )
+        invalid = valid.assign(gift_date=["not-a-date"])
+        transformer = EncounterTransformer(encounter_df=encounters)
+
+        with pytest.raises(ValueError, match="gift_date.*date-like"):
+            if phase == "fit":
+                transformer.fit(invalid)
+            else:
+                transformer.fit(valid).transform(invalid)
+
     def test_missing_discharge_dates_produce_nan(self, gift_df_with_ids):
         """Donors not in encounter_df get NaN for days_since_last_discharge."""
         enc = pd.DataFrame(


### PR DESCRIPTION
Fixes #163.

Normalizes the gift-date column before scikit-learn validates the mixed-dtype frame, so both strings and `datetime64` inputs work. Invalid non-missing dates now raise a column-specific error.

Validation: `make ci` (1,951 passed, 25 skipped; 97.44% coverage).
