### PR TITLE
fix: WealthPercentileTransformer silent no-op and dead branch, EncounterTransformer datetime64 rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- `WealthPercentileTransformer.fit`'s dead `hasattr(X, "columns")` branch is
+  removed: `validate_data` already returns a NumPy array and already sets
+  `feature_names_in_` for DataFrame input, so the branch never ran. Reported
+  as #168 and independently fixed by two duplicate PRs on the same evening,
+  #175 (@HeaTTap) and #176 (@Larslllllll); this change lands that fix and
+  credits both. See "Claiming an issue" in `CONTRIBUTING.md` for the process
+  fix that should prevent the next one.
+- `WealthPercentileTransformer(wealth_cols=[...])` now raises `ValueError`
+  instead of silently doing nothing when none of the named columns exist in
+  the training frame. A caller who names specific columns and gets none of
+  them is one typo away from training a model silently missing its wealth
+  signal. Closes #156.
+- `EncounterTransformer` no longer rejects a `gift_date` column already
+  parsed to `datetime64`, which previously raised
+  `numpy.exceptions.DTypePromotionError` deep inside `validate_data` (numpy
+  cannot promote `datetime64` and `float64` into one array dtype). A
+  DataFrame mixing a datetime64 column with numeric ones is now cast to
+  `object` dtype first. Any real loader
+  (`pd.read_csv(..., parse_dates=[...])`, a SQL read, this package's own
+  `make_donor_panel`) hands back exactly this column mix, so the previous
+  behavior rejected the common case and accepted only pre-formatted date
+  strings. Closes #163.
+
 ### Changed
 - README coverage badge now links to `pyproject.toml` and reads "≥92% floor"
   rather than a bare "≥92%". It was a static shields.io string with no tie to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,14 @@ done. A first PR does not need to be big; docs fixes and missing tests are
 genuinely wanted. Comment on the issue to claim it, and ask there if anything in
 this guide does not work; a question is a valid contribution too.
 
+### Claiming an issue
+
+Comment on the issue before you open a pull request, and wait for a maintainer
+to assign it to you; we assign within 24 hours. This is not bureaucracy:
+issues #175 and #176 were two people solving the same four-line problem on the
+same evening, and one of them wasted their time. If an issue already has an
+assignee, pick another one; the `good first issue` label always has open ones.
+
 ## Setup
 
 Fork the repository on GitHub first; you will not have push access to

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,7 +48,18 @@ contribution. Code, docs, tests, and review all count.
 - **Lars** ([@Larslllllll](https://github.com/Larslllllll)): added the missing
   unit-test coverage for `WealthPercentileTransformer`'s all-missing and
   partially-missing column branches in `WealthPercentileTransformer` (closes
-  [#169](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/169)).
+  [#169](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/169)), and
+  identified the dead `hasattr(X, "columns")` branch in
+  `WealthPercentileTransformer.fit`
+  ([#176](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/176), closes
+  [#168](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/168)).
+- [@HeaTTap](https://github.com/HeaTTap): independently identified and fixed the
+  same dead `hasattr(X, "columns")` branch in `WealthPercentileTransformer.fit`
+  ([#175](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/175), closes
+  [#168](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/168)). Two
+  people fixing the same four-line problem on the same evening was the
+  project's process failure, not either contributor's; see "Claiming an issue"
+  in `CONTRIBUTING.md`.
 
 ## Getting listed
 

--- a/philanthropy/preprocessing/_encounters.py
+++ b/philanthropy/preprocessing/_encounters.py
@@ -91,6 +91,22 @@ def _apply_as_of_cutoff(
     return enc[keep]
 
 
+def _avoid_dtype_promotion(X: Any) -> Any:
+    """Cast a DataFrame with a parsed datetime column to ``object`` dtype.
+
+    ``validate_data`` converts ``X`` to a single-dtype array, and numpy cannot
+    promote ``datetime64`` together with ``int``/``float`` into one dtype. A
+    caller's own loader (``pd.read_csv(parse_dates=...)``, a SQL read,
+    ``philanthropy.datasets.make_donor_panel``) hands back exactly this
+    column mix, so ``gift_date_col`` must not need pre-formatting to strings.
+    """
+    if isinstance(X, pd.DataFrame) and any(
+        pd.api.types.is_datetime64_any_dtype(dt) for dt in X.dtypes
+    ):
+        return X.astype(object)
+    return X
+
+
 def _warn_if_unbounded(
     enc: pd.DataFrame, discharge_col: str, gift_dates: Any, class_name: str
 ) -> None:
@@ -422,7 +438,9 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
             if isinstance(X, pd.DataFrame) and self.gift_date_col in X.columns
             else None
         )
-        X = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
+        X = validate_data(
+            self, _avoid_dtype_promotion(X), dtype=None, ensure_all_finite="allow-nan", reset=True
+        )
         self.n_features_in_ = X.shape[1]
 
         # --- Build encounter summary (fit-time only, no leakage from X) ---
@@ -504,7 +522,9 @@ class EncounterTransformer(TransformerMixin, BaseEstimator):
             n_cols = np.shape(X)[1] if len(np.shape(X)) > 1 else 1
             input_cols = [f"x{i}" for i in range(n_cols)]
 
-        X = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=False)
+        X = validate_data(
+            self, _avoid_dtype_promotion(X), dtype=None, ensure_all_finite="allow-nan", reset=False
+        )
         X_out = pd.DataFrame(X, columns=input_cols)
         
         self._validate_X(X_out)

--- a/philanthropy/preprocessing/_wealth_percentile.py
+++ b/philanthropy/preprocessing/_wealth_percentile.py
@@ -40,6 +40,12 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
             Fitted transformer. Freezes ``feature_names_in_``,
             ``imputed_cols_``, and ``percentile_lookup_``.
 
+        Raises
+        ------
+        ValueError
+            If ``wealth_cols`` is set but none of the named columns are
+            present in ``X``.
+
         Notes
         -----
         ``percentile_lookup_`` stores the sorted training values per wealth
@@ -47,11 +53,11 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
         training distribution, not against the batch being transformed.
         """
         X = validate_data(self, X, ensure_all_finite="allow-nan", reset=True)
-        
-        if hasattr(X, "columns"):
-             self.feature_names_in_ = np.array(X.columns.tolist(), dtype=object)
-        elif not hasattr(self, "feature_names_in_"):
-             self.feature_names_in_ = np.array([f"x{i}" for i in range(X.shape[1])], dtype=object)
+
+        # validate_data has already set feature_names_in_ when the input was a
+        # DataFrame; only the array-input path needs a fallback name here.
+        if not hasattr(self, "feature_names_in_"):
+            self.feature_names_in_ = np.array([f"x{i}" for i in range(X.shape[1])], dtype=object)
 
         # Use feature_names_in_ to resolve columns
         if self.wealth_cols is not None:
@@ -70,8 +76,14 @@ class WealthPercentileTransformer(TransformerMixin, BaseEstimator):
             self.percentile_lookup_[col] = np.sort(valid_vals)
 
         if len(self.imputed_cols_) == 0 and self.wealth_cols is not None:
-             # If we expected columns but found none, we should probably warn or raise
-             pass
+            raise ValueError(
+                f"wealth_cols={self.wealth_cols!r} matched none of the columns "
+                f"seen at fit time ({list(self.feature_names_in_)}). Naming "
+                "columns that do not exist is a mistake, not a preference "
+                "for skipping them silently: fix the name, or omit "
+                "wealth_cols to fall back to the built-in net_worth / "
+                "real_estate / stock / capacity heuristic."
+            )
 
         return self
 

--- a/scripts/issue-drafts/_TEMPLATE.md
+++ b/scripts/issue-drafts/_TEMPLATE.md
@@ -62,10 +62,11 @@ make riskcov
 
 ### First time here?
 
-Read [CONTRIBUTING.md](../../CONTRIBUTING.md) and [AGENTS.md](../../AGENTS.md).
-Docs-only fix? Use GitHub's web editor and open the PR from there, no local setup
-needed. Add a `## [Unreleased]` CHANGELOG entry and yourself to `CONTRIBUTORS.md` in
-the same PR.
+**Comment here to claim this issue before opening a PR**, and wait for a maintainer
+to assign it to you; we assign within 24 hours. Read [CONTRIBUTING.md](../../CONTRIBUTING.md)
+and [AGENTS.md](../../AGENTS.md). Docs-only fix? Use GitHub's web editor and open the
+PR from there, no local setup needed. Add a `## [Unreleased]` CHANGELOG entry and
+yourself to `CONTRIBUTORS.md` in the same PR.
 ```
 
 ## Keeping the feed stocked

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -410,6 +410,33 @@ class TestEncounterTransformer:
         assert "patient_mrn" not in out.columns
         assert "full_name" not in out.columns
 
+    def test_accepts_parsed_datetime64_gift_date(self):
+        """A gift_date column already parsed to datetime64 must not raise.
+
+        Any real loader (pd.read_csv(parse_dates=...), a SQL read,
+        make_donor_panel) hands back exactly this column mix: datetime64
+        alongside int/float. Issue #163.
+        """
+        enc = pd.DataFrame(
+            {"donor_id": [1, 2], "discharge_date": ["2023-05-10", "2022-11-01"]}
+        )
+        gifts = pd.DataFrame(
+            {
+                "donor_id": [1, 2],
+                "gift_date": pd.to_datetime(["2023-08-15", "2023-03-20"]),
+                "gift_amount": [5000.0, 500.0],
+            }
+        )
+        t = EncounterTransformer(
+            encounter_df=enc,
+            discharge_col="discharge_date",
+            gift_date_col="gift_date",
+            merge_key="donor_id",
+        ).set_output(transform="pandas")
+        out = t.fit_transform(gifts)
+        assert out.loc[0, "days_since_last_discharge"] == 97.0
+        assert out.loc[1, "days_since_last_discharge"] == 139.0
+
     def test_all_nan_discharge_warns(self, gift_df_with_ids):
         enc = pd.DataFrame(
             {"donor_id": [101], "discharge_date": [None]}
@@ -790,3 +817,25 @@ class TestWealthPercentileTransformer:
         assert not pd.isna(out.loc[4, "net_worth_pct_rank"])
         # Other column passes through unchanged
         assert out["other"].tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    def test_unmatched_wealth_cols_raises(self):
+        # A wealth_cols name that matches nothing in X is a typo or a schema
+        # mismatch, not an intentional no-op: silently training without the
+        # wealth signal the caller asked for is the wrong default. Issue #156.
+        df = pd.DataFrame({"net_worth": [1.0, 2.0, 3.0], "other": [1.0, 2.0, 3.0]})
+        t = WealthPercentileTransformer(wealth_cols=["estimated_networth"])
+        with pytest.raises(ValueError, match="estimated_networth"):
+            t.fit(df)
+
+    def test_feature_names_match_for_frame_and_array_input(self):
+        # Fit one transformer on a DataFrame and another on df.to_numpy(), then
+        # assert both produce the documented get_feature_names_out() shape:
+        # the DataFrame-fitted one keeps real column names, the array-fitted
+        # one falls back to x0..xn. Pins the behaviour the deleted
+        # hasattr(X, "columns") branch appeared to provide, so removing it
+        # (issue #168) is provably safe rather than merely plausible.
+        df = pd.DataFrame({"net_worth": [1.0, 2.0, 3.0], "other": [1.0, 2.0, 3.0]})
+        a = WealthPercentileTransformer().fit(df)
+        b = WealthPercentileTransformer().fit(df.to_numpy())
+        assert list(a.get_feature_names_out()) == ["net_worth", "other", "net_worth_pct_rank"]
+        assert list(b.get_feature_names_out()) == ["x0", "x1"]


### PR DESCRIPTION
## Summary
Three real defects found during a pass over the JOSS-prep plan, plus the process fix for how the third one happened.

- `WealthPercentileTransformer(wealth_cols=[...])` now raises `ValueError` instead of silently training without the wealth signal when none of the named columns exist in `X`. A typo'd column name was indistinguishable from an intentional no-op. Closes #156.
- `WealthPercentileTransformer.fit`'s dead `hasattr(X, "columns")` branch is removed (`validate_data` already returns a NumPy array and already sets `feature_names_in_` for DataFrame input). Two contributors independently fixed this same branch the same evening, #175 (@HeaTTap) and #176 (@Larslllllll); this PR lands that fix and credits both in `CONTRIBUTORS.md`. Closes #168.
- `EncounterTransformer` no longer rejects a `gift_date` column already parsed to `datetime64`. Any real loader (`pd.read_csv(parse_dates=...)`, a SQL read, this package's own `make_donor_panel`) hands back exactly that column mix, and `validate_data`'s numpy promotion of `datetime64` against `float64` raised before the transformer got a chance to read it. Closes #163.
- `CONTRIBUTING.md` gets a "Claiming an issue" rule (comment before you open a PR, wait for assignment) so the #175/#176 duplication doesn't repeat; the issue-draft template states it inline too.

Also filed 5 good-first-issue drafts from `scripts/issue-drafts/` as real GitHub issues (#181-#185), each re-verified against current line numbers/greps first. Not part of this diff since they're process, not code.

## Test plan
- [x] New regression tests for all three fixes: `test_unmatched_wealth_cols_raises`, `test_feature_names_match_for_frame_and_array_input`, `test_accepts_parsed_datetime64_gift_date`
- [x] `make ci` green
- [x] `make riskcov` green (97% branch over the risk-tier subtree, 93% floor)
- [x] Full suite green