### PR TITLE
docs: add the claim-before-PR rule, credit @HeaTTap for the #168 fix attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Missing physician columns continue to report zero distinct physicians, and
   both optional-column paths now have regression coverage. Closes #151.
 
+### Added
+- `CONTRIBUTING.md` gets a "Claiming an issue" rule: comment on an issue before
+  opening a PR, and wait for a maintainer to assign it. Issues #175 and #176
+  were two people independently fixing the same four-line bug the same
+  evening; that was a process failure on this project's side, not a mistake
+  by either contributor. The issue-draft template now states the same rule
+  inline, so every newly filed `good first issue` carries the reminder in its
+  own body rather than depending on a reader following a link.
+
 ### Changed
 - `WealthPercentileTransformer.fit` now raises an actionable `ValueError` when
   an explicit `wealth_cols` list matches no training column; partial matches

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,14 @@ done. A first PR does not need to be big; docs fixes and missing tests are
 genuinely wanted. Comment on the issue to claim it, and ask there if anything in
 this guide does not work; a question is a valid contribution too.
 
+### Claiming an issue
+
+Comment on the issue before you open a pull request, and wait for a maintainer
+to assign it to you; we assign within 24 hours. This is not bureaucracy:
+issues #175 and #176 were two people solving the same four-line problem on the
+same evening, and one of them wasted their time. If an issue already has an
+assignee, pick another one; the `good first issue` label always has open ones.
+
 ## Setup
 
 Fork the repository on GitHub first; you will not have push access to

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,12 @@ contribution. Code, docs, tests, and review all count.
   unit-test coverage for `WealthPercentileTransformer`'s all-missing and
   partially-missing column branches in `WealthPercentileTransformer` (closes
   [#169](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/169)).
+- [@HeaTTap](https://github.com/HeaTTap): independently identified and fixed the
+  dead `hasattr(X, "columns")` branch in `WealthPercentileTransformer.fit`
+  ([#175](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/175)), later
+  subsumed by [#179](https://github.com/PhilanthroPy-Project/PhilanthroPy/pull/179),
+  which carried the same fix (closes
+  [#168](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/168)).
 - [@be-student](https://github.com/be-student): made `EncounterTransformer`
   accept parsed gift dates and report invalid dates with a column-specific
   error (closes [#163](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/163)).

--- a/scripts/issue-drafts/_TEMPLATE.md
+++ b/scripts/issue-drafts/_TEMPLATE.md
@@ -62,10 +62,11 @@ make riskcov
 
 ### First time here?
 
-Read [CONTRIBUTING.md](../../CONTRIBUTING.md) and [AGENTS.md](../../AGENTS.md).
-Docs-only fix? Use GitHub's web editor and open the PR from there, no local setup
-needed. Add a `## [Unreleased]` CHANGELOG entry and yourself to `CONTRIBUTORS.md` in
-the same PR.
+**Comment here to claim this issue before opening a PR**, and wait for a maintainer
+to assign it to you; we assign within 24 hours. Read [CONTRIBUTING.md](../../CONTRIBUTING.md)
+and [AGENTS.md](../../AGENTS.md). Docs-only fix? Use GitHub's web editor and open the
+PR from there, no local setup needed. Add a `## [Unreleased]` CHANGELOG entry and
+yourself to `CONTRIBUTORS.md` in the same PR.
 ```
 
 ## Keeping the feed stocked


### PR DESCRIPTION
## Summary
Two follow-ups after the #175/#176 duplicate-PR triage (now resolved: #175/#176 closed, #168/#156/#163/#151 all closed via #179/#180/#178):

- `CONTRIBUTING.md` gets a "Claiming an issue" rule: comment on an issue before opening a PR, and wait for a maintainer to assign it. The issue-draft template states the same rule inline.
- Credits @HeaTTap in `CONTRIBUTORS.md` for independently identifying and fixing the same dead branch as @Larslllllll (#175, subsumed by #179). @Larslllllll was already credited via #174; @HeaTTap had no line.

## Test plan
- [x] `make ci` green
- [x] Doc-only change, no source touched