### PR TITLE
docs: lead the generative AI disclosure with human design authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   own body rather than depending on a reader following a link.
 
 ### Changed
+- Generative AI disclosure reordered in `paper.md`, `README.md`, and
+  `philanthropy/__init__.py` to lead with human design authority and human
+  review, then state the scope of the assistance within those constraints. The
+  facts are unchanged: the scope remains package-wide, no numeric split is
+  estimated, and the review gate is still what the disclosure rests on. Only the
+  order and emphasis moved, so the disclosure stays consistent with `AGENTS.md`
+  and the public commit history.
 - `WealthPercentileTransformer.fit` now raises an actionable `ValueError` when
   an explicit `wealth_cols` list matches no training column; partial matches
   and automatic detection remain unchanged.

--- a/README.md
+++ b/README.md
@@ -277,16 +277,18 @@ benchmark of PhilanthroPy.** To cite the software itself, see [`CITATION.cff`](C
 
 ## Generative AI disclosure
 
-AI assistance (Claude Code) was used during development of this package, across
-implementation, tests, and documentation, in an agentic workflow rather than
-line completion alone.
+**The design is the author's, and the AI-assisted work was bounded by
+constraints set in advance.** The leakage-safety contract (every fitted
+statistic is computed on training data inside `fit` and frozen before
+`transform`/`predict`), the dependency rule (scikit-learn, pandas, numpy,
+matplotlib, seaborn; no deep learning frameworks), the estimator conventions,
+and the stability tiers all predate any generated code. Generated code that
+violated them was rejected rather than merged. The author made every core design
+decision and reviewed, edited, and validated all AI-assisted output.
 
-**What was not generated.** The design constraints are the author's and predate
-any generated code: the leakage-safety contract (every fitted statistic is
-computed on training data inside `fit` and frozen before `transform`/`predict`),
-the dependency rule (scikit-learn, pandas, numpy, matplotlib, seaborn; no deep
-learning frameworks), the estimator conventions, and the stability tiers.
-Generated code that violated them was rejected rather than merged.
+**Scope of the assistance.** Within those constraints, AI assistance (Claude
+Code) was used during development of this package, across implementation, tests,
+and documentation, in an agentic workflow rather than line completion alone.
 
 **Human review.** Nothing lands without the full gate green. Locally, `make ci`
 runs flake8, mypy, the docstring examples, and the test suite against a 92%

--- a/paper.md
+++ b/paper.md
@@ -186,23 +186,23 @@ on the standard scientific Python stack [@scikit-learn; @numpy; @pandas].
 
 # AI usage disclosure
 
-Generative AI assistance (Anthropic Claude, used through Claude Code in an
-agentic workflow rather than line completion alone) was used during development
-of this package across implementation, tests, documentation, and the drafting of
-this paper.
+The design of this package is the author's, and the AI-assisted work was bounded
+by constraints the author set in advance. The freeze-at-fit contract, the
+dependency rule, the estimator conventions, the stability tiers, and the
+compliance posture all predate any generated code, and generated code that
+violated them was rejected rather than merged. The author made every core design
+decision, and reviewed, edited, and validated all AI-assisted output, including
+every claim and citation in this paper.
 
-The design constraints are the author's and predate any generated code: the
-freeze-at-fit contract, the dependency rule, the estimator conventions, the
-stability tiers, and the compliance posture. Generated code that violated them
-was rejected rather than merged. No numeric split between authored and
-AI-assisted output is offered, because the author has not measured one and
-declines to estimate it; the review gate is stated instead. Nothing lands
-without the full gate green: flake8, mypy, the docstring examples, the test
-suite against the coverage floors above, an OS and Python-version matrix, a
-dependency-floor install, a packaging-metadata check, and the conformance
-battery. The author reviewed, edited, and validated all AI-assisted output,
-including every claim and citation in this paper, and made the core design
-decisions.
+Within those constraints, generative AI assistance (Anthropic Claude, used
+through Claude Code in an agentic workflow rather than line completion alone)
+was used during development across implementation, tests, documentation, and the
+drafting of this paper. No numeric split between authored and AI-assisted output
+is offered, because the author has not measured one and declines to estimate it;
+the review gate is stated instead. Nothing lands without the full gate green:
+flake8, mypy, the docstring examples, the test suite against the coverage floors
+above, an OS and Python-version matrix, a dependency-floor install, a
+packaging-metadata check, and the conformance battery.
 
 # Acknowledgements
 

--- a/philanthropy/__init__.py
+++ b/philanthropy/__init__.py
@@ -6,11 +6,13 @@ in the nonprofit sector.
 
 Generative AI disclosure
 ------------------------
-AI assistance (Claude Code) was used during development of this package.
-The scope is package-wide rather than specific to any one module, so the
-disclosure lives here rather than being stamped on every module. See the
-"Generative AI disclosure" section of README.md for how the tools were
-used and what human review was performed.
+The design of this package is the author's, who made every core design
+decision and reviewed, edited, and validated all AI-assisted output.
+Within constraints set in advance, AI assistance (Claude Code) was used
+during development. The scope is package-wide rather than specific to any
+one module, so the disclosure lives here rather than being stamped on
+every module. See the "Generative AI disclosure" section of README.md for
+how the tools were used and what human review was performed.
 """
 
 from importlib.metadata import PackageNotFoundError, version as _version


### PR DESCRIPTION
## What

Reorders the generative AI disclosure in `paper.md`, `README.md`, and
`philanthropy/__init__.py` so each one opens with what the author decided and
reviewed, then states the scope of the AI assistance within those constraints.

## Why

JOSS requires the AI usage disclosure as a named section, and the January 2026
policy is explicit that a pro forma disclosure is a problem. The previous
ordering led with the tool and reached the human review gate last, which reads
as a tool-first disclosure even though the substance was already there.

The facts are unchanged in all three places:

- the scope is still package-wide, not per-module;
- no numeric split between authored and AI-assisted output is offered, because
  the author has not measured one;
- the disclosure still rests on the review gate (flake8, mypy, doctests, the
  suite against both coverage floors, the OS and Python matrix, the
  dependency-floor install, the packaging check, the conformance battery),
  not on a percentage.

Only the order and the emphasis moved, which keeps `paper.md` consistent with
`README.md`, `AGENTS.md`, and the public commit history.

## Verification

- `make ci`: 1977 passed, 4 skipped, total coverage 97.77% against the 92.0% floor. Exit 0.
- `make riskcov`: risk-tier TOTAL 97%. Exit 0.
- `draft-pdf` will re-render `paper.md` on this PR; the paper stays within the
  1,750-word ceiling (no words added on net).

## Credit

`CHANGELOG.md` entry added under `## [Unreleased] / ### Changed`; author already
listed in `CONTRIBUTORS.md`.