### PR TITLE
docs: credit the R prior art this package descends from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   both optional-column paths now have regression coverage. Closes #151.
 
 ### Added
+- `README.md` gets a `### Prior art` section under Research, crediting the R
+  repositories this package is downstream of: `michaelpawlus/pg_donors` (2015),
+  `michaelpawlus/fundraising_analytics` (2016), and `crazybilly/fundRaising`
+  (2021). `PlannedGivingIntentScorer` is named as the descendant of `pg_donors`,
+  and `RFMTransformer`, `DonorPropensityModel`, `MovesManagementClassifier`,
+  `FiscalYearTransformer`, and `LapsePredictor` are matched to the R scripts and
+  functions that did the same job first. The omission read as a state-of-the-field
+  gap: `paper.md` compares against Python libraries only, and nothing anywhere in
+  the project acknowledged the R prior art.
 - `CONTRIBUTING.md` gets a "Claiming an issue" rule: comment on an issue before
   opening a PR, and wait for a maintainer to assign it. Issues #175 and #176
   were two people independently fixing the same four-line bug the same

--- a/README.md
+++ b/README.md
@@ -273,6 +273,36 @@ This is the library author's own related work on the same problem space, using a
 different dataset and its own models. **It is not an independent evaluation or a
 benchmark of PhilanthroPy.** To cite the software itself, see [`CITATION.cff`](CITATION.cff).
 
+### Prior art
+
+Open-source fundraising analytics started in R, and this package is downstream of
+that work rather than the first of its kind.
+
+- **[`michaelpawlus/pg_donors`](https://github.com/michaelpawlus/pg_donors)** (R,
+  2015) is exploratory analysis plus a `caret` classifier for planned-giving
+  prospects, imputing missing median household income to the column median before
+  fitting. `PlannedGivingIntentScorer` is its descendant: the same problem, the
+  same imputation idea, moved into an estimator whose fill values are computed in
+  `fit` and frozen before `transform` (`WealthScreeningImputer`) so the same script
+  cannot leak the scoring batch's median back into training.
+- **[`michaelpawlus/fundraising_analytics`](https://github.com/michaelpawlus/fundraising_analytics)**
+  (R, 2016) collects the sector's recurring jobs as standalone scripts: RFM
+  scoring, an annual-giving propensity model, class-imbalance correction on
+  planned-giving prospects, IRS 990 merges, portfolio management. `RFMTransformer`,
+  `DonorPropensityModel`, and `MovesManagementClassifier` cover the same ground as
+  pipeline-safe estimators.
+- **[`crazybilly/fundRaising`](https://github.com/crazybilly/fundRaising)** (R,
+  2021) is a packaged utility layer for advancement shops: fiscal-year conversion
+  (`fy`, `fy_quarters`, `fydaynum`), lapsed-donor flags, giving-level cuts, and
+  consecutive-giving runs. `FiscalYearTransformer` and `LapsePredictor` are the
+  scikit-learn-shaped equivalents.
+
+The gap this package fills is not the modelling, which those repositories already
+did. It is packaging the sector's steps as `check_estimator`-compliant, composable
+estimators with an explicit leakage contract, in the language the rest of the
+machine-learning stack is written in. See [State of the field](paper.md#state-of-the-field)
+for the comparison against current Python libraries.
+
 ---
 
 ## Generative AI disclosure


### PR DESCRIPTION
## What

Adds a `### Prior art` section to `README.md`, under Research.

## Why

The README has 21 headings and none of them acknowledged the R repositories that
did this work first. `paper.md`'s State of the field compares against Python
libraries only (`feature-engine`, `mlxtend`, `sktime`, `pymc-marketing`, MAPIE,
`crepes`, `scikit-uplift`), so nothing anywhere in the project pointed at the
actual lineage. That reads as a state-of-the-field gap, and it is also just
uncredited.

## What it says

| Prior art | What it is | Descendant here |
|---|---|---|
| [`michaelpawlus/pg_donors`](https://github.com/michaelpawlus/pg_donors) (R, 2015) | `caret` classifier for planned-giving prospects; imputes missing median household income to the column median before fitting | `PlannedGivingIntentScorer`, with the imputation moved into `WealthScreeningImputer` where the fill value is frozen at `fit` |
| [`michaelpawlus/fundraising_analytics`](https://github.com/michaelpawlus/fundraising_analytics) (R, 2016) | RFM scoring, annual-giving propensity, class-imbalance correction on planned-giving prospects, portfolio management, IRS 990 merges | `RFMTransformer`, `DonorPropensityModel`, `MovesManagementClassifier` |
| [`crazybilly/fundRaising`](https://github.com/crazybilly/fundRaising) (R, 2021) | packaged utilities: `fy`, `fy_quarters`, `fydaynum`, lapsed-donor flags, giving-level cuts, consecutive-giving runs | `FiscalYearTransformer`, `LapsePredictor` |

The section states plainly that the modelling is not this package's contribution.
The contribution is packaging the sector's steps as `check_estimator`-compliant,
composable estimators with an explicit leakage contract, in the language the rest
of the ML stack is written in.

Every repository, date, language, and file referenced was checked against the
GitHub API rather than recalled.

## Checks

- `pytest tests/test_doc_examples.py tests/test_documented_contracts.py` — 22 passed
- Pre-push hook ran the full suite before this branch was pushed
- `CHANGELOG.md` updated under `## [Unreleased]`; author already listed in `CONTRIBUTORS.md`

Docs only; no source or test files touched.