### PR TITLE
test: cover EncounterTransformer non-DataFrame validation branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- Tests for `EncounterTransformer` non-DataFrame `encounter_df` TypeError and
+  `_validate_X` early-return for array input. Closes #152.
+
 ### Fixed
 - `GratefulPatientFeaturizer` now reports one fallback `general` service line
   per known donor when the encounter table omits the service-line column.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,3 +76,4 @@ too; say so in the PR and it stays out.
 Not sure where to start? See
 [CONTRIBUTING.md](CONTRIBUTING.md) and the
 [good first issues](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+- [@haas26p-ctrl](https://github.com/haas26p-ctrl): added EncounterTransformer validation-branch tests ([#152](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/152)).

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -453,6 +453,19 @@ class TestEncounterTransformer:
             t.fit(gift_df_with_ids)
             assert any(isinstance(warning.category, type(UserWarning)) for warning in w)
 
+    def test_encounter_transformer_rejects_non_dataframe_encounter_df(self, gift_df_with_ids):
+        """List-of-dicts encounter_df must raise TypeError from _validate_encounter_df."""
+        t = EncounterTransformer(
+            encounter_df=[{"donor_id": 1, "discharge_date": "2022-01-01"}]
+        )
+        with pytest.raises(TypeError, match="must be a pd.DataFrame"):
+            t.fit(gift_df_with_ids)
+
+    def test_encounter_transformer_validate_x_passes_arrays_through(self, encounter_df):
+        """Array X goes through _validate_X early-return; public fit succeeds."""
+        t = EncounterTransformer(encounter_df=encounter_df)
+        assert t.fit(np.zeros((2, 3))) is t
+
 
 # --------------------------------------------------------------------------- #
 # EncounterRecencyTransformer: parameter validation and input shapes


### PR DESCRIPTION
## Summary
Test-only coverage for two unexecuted validation branches in `EncounterTransformer`:

- `test_encounter_transformer_rejects_non_dataframe_encounter_df` — list-of-dicts `encounter_df` raises `TypeError` matching `must be a pd.DataFrame`
- `test_encounter_transformer_validate_x_passes_arrays_through` — `assert t.fit(np.zeros((2, 3))) is t` (array `X` uses the public `fit` path; `_validate_X` early-return)

No source changes under `philanthropy/`. CHANGELOG + CONTRIBUTORS updated.

Closes #152.

## Test plan
- [ ] `python -m pytest tests/test_preprocessing.py tests/test_as_of_cutoff.py --cov=philanthropy.preprocessing._encounters --cov-report=term-missing -q`
- [ ] `make ci` / `make riskcov`