### PR TITLE
refactor: extract validation block and remove dead complex-data guard in transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Fixed
+- `CRMCleaner` and `FiscalYearTransformer` now use a shared `_validate_X` helper,
+  and the unreachable `np.iscomplexobj` guard is removed. Complex data inside
+  object arrays bypasses the guard and is properly handled downstream. Closes #155.
 - `GratefulPatientFeaturizer` now reports one fallback `general` service line
   per known donor when the encounter table omits the service-line column.
   Missing physician columns continue to report zero distinct physicians, and

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -53,6 +53,17 @@ def _get_pandas_output(estimator: Any) -> bool:
     return False
 
 
+def _validate_X(estimator: BaseEstimator, X: Any, reset: bool) -> np.ndarray:
+    """Validate data while allowing mixed types by falling back to object dtype."""
+    try:
+        return validate_data(estimator, X, dtype=None, ensure_all_finite="allow-nan", reset=reset)
+    except Exception as e:
+        if "Complex data not supported" in str(e):
+            raise
+        X_val = X.astype(object) if hasattr(X, "astype") else X
+        return validate_data(estimator, X_val, dtype=None, ensure_all_finite="allow-nan", reset=reset)
+
+
 def _coerce_currency_to_float(col: pd.Series) -> pd.Series:
     """Parse a gift-amount column to float64, tolerating currency formatting.
 
@@ -161,19 +172,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
             If ``fiscal_year_start`` is invalid or ``X`` contains complex data.
         """
         validate_fiscal_year_start(self.fiscal_year_start)
-        
-        # Try standard validation, fallback to object for mixed-type DataFrames or promotion errors
-        try:
-            X_validated = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
-        except Exception as e:
-            if "Complex data not supported" in str(e):
-                raise
-            X_val = X.astype(object) if hasattr(X, "astype") else X
-            X_validated = validate_data(self, X_val, dtype=None, ensure_all_finite="allow-nan", reset=True)
-            
-        if np.iscomplexobj(X_validated):
-            raise ValueError("Complex data not supported")
-        
+        _validate_X(self, X, reset=True)
         return self
 
     def transform(self, X: Any) -> np.ndarray | pd.DataFrame:
@@ -199,16 +198,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
             If ``X`` contains complex data.
         """
         check_is_fitted(self)
-        try:
-            X_arr = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=False)
-        except Exception as e:
-            if "Complex data not supported" in str(e):
-                raise
-            X_val = X.astype(object) if hasattr(X, "astype") else X
-            X_arr = validate_data(self, X_val, dtype=None, ensure_all_finite="allow-nan", reset=False)
-
-        if np.iscomplexobj(X_arr):
-            raise ValueError("Complex data not supported")
+        X_arr = _validate_X(self, X, reset=False)
 
         X_df = pd.DataFrame(X_arr, columns=getattr(self, "feature_names_in_", None)).copy()
         
@@ -287,16 +277,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
             If ``fiscal_year_start`` is invalid or ``X`` contains complex data.
         """
         validate_fiscal_year_start(self.fiscal_year_start)
-        try:
-            X_validated = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
-        except Exception as e:
-            if "Complex data not supported" in str(e):
-                raise
-            X_val = X.astype(object) if hasattr(X, "astype") else X
-            X_validated = validate_data(self, X_val, dtype=None, ensure_all_finite="allow-nan", reset=True)
-            
-        if np.iscomplexobj(X_validated):
-            raise ValueError("Complex data not supported")
+        _validate_X(self, X, reset=True)
         return self
 
     def transform(self, X: Any) -> np.ndarray | pd.DataFrame:
@@ -325,16 +306,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
             If ``X`` contains complex data.
         """
         check_is_fitted(self)
-        try:
-            X_arr = validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=False)
-        except Exception as e:
-            if "Complex data not supported" in str(e):
-                raise
-            X_val = X.astype(object) if hasattr(X, "astype") else X
-            X_arr = validate_data(self, X_val, dtype=None, ensure_all_finite="allow-nan", reset=False)
-        
-        if np.iscomplexobj(X_arr):
-            raise ValueError("Complex data not supported")
+        X_arr = _validate_X(self, X, reset=False)
         
         X_df = pd.DataFrame(X_arr, columns=getattr(self, "feature_names_in_", None)).copy()
         

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -169,7 +169,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         Raises
         ------
         ValueError
-            If ``fiscal_year_start`` is invalid or ``X`` contains complex data.
+            If ``fiscal_year_start`` is invalid or ``X`` fails validation (e.g. complex-dtype input).
         """
         validate_fiscal_year_start(self.fiscal_year_start)
         _validate_X(self, X, reset=True)
@@ -195,7 +195,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         sklearn.exceptions.NotFittedError
             If :meth:`fit` has not been called yet.
         ValueError
-            If ``X`` contains complex data.
+            If ``X`` fails validation (e.g. complex-dtype input).
         """
         check_is_fitted(self)
         X_arr = _validate_X(self, X, reset=False)
@@ -274,7 +274,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         Raises
         ------
         ValueError
-            If ``fiscal_year_start`` is invalid or ``X`` contains complex data.
+            If ``fiscal_year_start`` is invalid or ``X`` fails validation (e.g. complex-dtype input).
         """
         validate_fiscal_year_start(self.fiscal_year_start)
         _validate_X(self, X, reset=True)
@@ -303,7 +303,7 @@ class FiscalYearTransformer(TransformerMixin, BaseEstimator):
         sklearn.exceptions.NotFittedError
             If :meth:`fit` has not been called yet.
         ValueError
-            If ``X`` contains complex data.
+            If ``X`` fails validation (e.g. complex-dtype input).
         """
         check_is_fitted(self)
         X_arr = _validate_X(self, X, reset=False)


### PR DESCRIPTION
This PR addresses #155. 

While looking into the repeated validation blocks in `_transformers.py`, I realized *why* the complex-data guard seemed unreachable. `validate_data()` returns an `object` dtype array when it falls back to mixed types (e.g. containing a mix of dates, strings, and complex numbers). Because of this, `np.iscomplexobj()` evaluates to `False` (since the overall array dtype is `object`, not `complex`), meaning the guard was silently bypassed and acting as pure dead code.

I've refactored the file by:
1. Extracting the duplicated `validate_data` try-except block into a single `_validate_X` helper function to DRY things up.
2. Removing the dead `iscomplexobj` check entirely. Complex numbers now bypass it naturally and are handled downstream by `_coerce_currency_to_float` (which coerces them to `NaN` and emits a warning, exactly as expected by the existing test suite).

All tests pass locally.

Closes #155
