### PR TITLE
chore: release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
-### Fixed
-- `CRMCleaner` and `FiscalYearTransformer` now use a shared `_validate_X` helper,
-  and the unreachable `np.iscomplexobj` guard is removed. Complex data inside
-  object arrays bypasses the guard and is properly handled downstream. Closes #155.
-- `GratefulPatientFeaturizer` now reports one fallback `general` service line
-  per known donor when the encounter table omits the service-line column.
-  Missing physician columns continue to report zero distinct physicians, and
-  both optional-column paths now have regression coverage. Closes #151.
+## [0.7.1] - 2026-09-08
 
 ### Added
 - `scripts/render_leakage_chart.py`, the figure companion to the two leakage
@@ -43,26 +36,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   inline, so every newly filed `good first issue` carries the reminder in its
   own body rather than depending on a reader following a link.
 
-### Changed
-- Generative AI disclosure reordered in `paper.md`, `README.md`, and
-  `philanthropy/__init__.py` to lead with human design authority and human
-  review, then state the scope of the assistance within those constraints. The
-  facts are unchanged: the scope remains package-wide, no numeric split is
-  estimated, and the review gate is still what the disclosure rests on. Only the
-  order and emphasis moved, so the disclosure stays consistent with `AGENTS.md`
-  and the public commit history.
-- `WealthPercentileTransformer.fit` now raises an actionable `ValueError` when
-  an explicit `wealth_cols` list matches no training column; partial matches
-  and automatic detection remain unchanged.
-- README coverage badge now links to `pyproject.toml` and reads "≥92% floor"
-  rather than a bare "≥92%". It was a static shields.io string with no tie to
-  the enforced number, so it would have silently lied had `fail_under` ever
-  moved. Not wiring a dynamic gist badge (`schneegans/dynamic-badges-action`):
-  that needs a personal-access-token secret this change doesn't have standing
-  to create, and Codecov/Coveralls are explicitly ruled out elsewhere in this
-  project's standing rules.
-
-### Added
 - Tests pinning the two untested branches of `WealthPercentileTransformer`:
   the all-missing column path (returns NaN ranks, keeps a stable output
   width, raises no warning) and the partially-missing column path (NaN
@@ -110,10 +83,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   working; `tests/test_examples.py`'s docstring now says notebooks are covered
   by `nbmake`, not by it.
 
-### Deprecated
-- `FiscalYearGroupedSplitter`'s default for `drop_repeat_donors` (currently `False`) is deprecated and will change to `True` in 0.8.0. Leaving it at its default now emits a `DeprecationWarning`. Pass `drop_repeat_donors=False` explicitly to silence the warning and retain current behavior. Closes #108, by @shubhrai23.
-
-### Added
 - `credit-guard` CI job: pull requests touching `philanthropy/` must also
   update this changelog, and the author must be credited in
   CONTRIBUTORS.md. Implemented as `scripts/check_credit.sh`, wired into
@@ -131,17 +100,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `philanthropy/` directory in the working directory cannot silently shadow the
   wheel and turn this into a second working-tree test. Windows is included
   because the main matrix is Linux plus macOS.
-### Fixed
-- `EncounterTransformer` now accepts parsed `datetime64` gift dates alongside
-  date strings, and reports unparseable values with the configured gift-date
-  column name instead of exposing NumPy's mixed-dtype promotion error. Closes
-  #163.
-- `CRMCleaner.transform` no longer silently corrupts complex amounts into
-  wrong finite floats: cells holding actual `complex` values are masked to
-  NaN with a `UserWarning` naming them, and a column where nothing parses
-  (all-complex included) still raises `could not parse` per the documented
-  contract. Closes #129.
-### Added
 - **`models.GiftIntervalCalibrator`**: distribution-free intervals on a dollar
   amount. Wraps an already-fitted regressor (`AskAmountRecommender`,
   `ShareOfWalletRegressor`, or any `predict`-per-row estimator) and calibrates on
@@ -184,6 +142,33 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   (#56)
 
 ### Changed
+- The `ShareOfWalletScorer` output rename describes itself as landing in 0.7.1
+  rather than 0.8.0. The docstring, the `get_legacy_feature_names_out` summary
+  line, its `DeprecationWarning` text, and the deprecations table in
+  `docs/reference/index.md` all named 0.8.0, which was the version this work was
+  staged for before the release was cut as a patch. The three future promises
+  are untouched and still say 0.8.0: `WealthScreeningImputerKNN(group_col_idx=...)`,
+  `philanthropy.utils.make_donor_dataset`, and the `FiscalYearGroupedSplitter`
+  `drop_repeat_donors` default flip. Removal of the legacy names accessor stays
+  at 0.9.0, which is more grace than the one-published-minor rule requires.
+- Generative AI disclosure reordered in `paper.md`, `README.md`, and
+  `philanthropy/__init__.py` to lead with human design authority and human
+  review, then state the scope of the assistance within those constraints. The
+  facts are unchanged: the scope remains package-wide, no numeric split is
+  estimated, and the review gate is still what the disclosure rests on. Only the
+  order and emphasis moved, so the disclosure stays consistent with `AGENTS.md`
+  and the public commit history.
+- `WealthPercentileTransformer.fit` now raises an actionable `ValueError` when
+  an explicit `wealth_cols` list matches no training column; partial matches
+  and automatic detection remain unchanged.
+- README coverage badge now links to `pyproject.toml` and reads "≥92% floor"
+  rather than a bare "≥92%". It was a static shields.io string with no tie to
+  the enforced number, so it would have silently lied had `fail_under` ever
+  moved. Not wiring a dynamic gist badge (`schneegans/dynamic-badges-action`):
+  that needs a personal-access-token secret this change doesn't have standing
+  to create, and Codecov/Coveralls are explicitly ruled out elsewhere in this
+  project's standing rules.
+
 - `ShareOfWalletScorer` output column 0 is renamed `sow_score` →
   `capacity_utilisation_ratio`. The formula was always capacity ÷ clipped
   modelled wealth: utilisation of estimated capacity, with no term for giving to
@@ -201,13 +186,34 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - `test_predict_methods_are_callable_with_x_alone_and_return_one_value_per_row`
   now skips non-estimator symbols in `models.__all__` instead of raising
   `KeyError` on the first one.
+- `CRMCleaner` and `FiscalYearTransformer` now use a shared `_validate_X` helper,
+  and the unreachable `np.iscomplexobj` guard is removed. Complex data inside
+  object arrays bypasses the guard and is properly handled downstream. Closes #155.
 
 ### Deprecated
+- `FiscalYearGroupedSplitter`'s default for `drop_repeat_donors` (currently `False`) is deprecated and will change to `True` in 0.8.0. Leaving it at its default now emits a `DeprecationWarning`. Pass `drop_repeat_donors=False` explicitly to silence the warning and retain current behavior. Closes #108, by @shubhrai23.
+
 - `philanthropy.utils.make_donor_dataset` moves to
   [`philanthropy.datasets.make_donor_dataset`](philanthropy/datasets/) and the
   old location emits a `DeprecationWarning`; removed in 0.8.0. The gift-level
   generator now lives next to `generate_synthetic_donor_data`, which is the
   canonical datasets home. Closes #111.
+
+### Fixed
+- `GratefulPatientFeaturizer` now reports one fallback `general` service line
+  per known donor when the encounter table omits the service-line column.
+  Missing physician columns continue to report zero distinct physicians, and
+  both optional-column paths now have regression coverage. Closes #151.
+
+- `EncounterTransformer` now accepts parsed `datetime64` gift dates alongside
+  date strings, and reports unparseable values with the configured gift-date
+  column name instead of exposing NumPy's mixed-dtype promotion error. Closes
+  #163.
+- `CRMCleaner.transform` no longer silently corrupts complex amounts into
+  wrong finite floats: cells holding actual `complex` values are masked to
+  NaN with a `UserWarning` naming them, and a column where nothing parses
+  (all-complex included) still raises `could not parse` per the documented
+  contract. Closes #129.
 
 ## [1.0.0] - TBD
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
     given-names: "Shivam Ashokbhai"
     orcid: "https://orcid.org/0009-0000-5110-6540"
     email: shivamlalakiya151299@gmail.com
-version: 0.7.0
-date-released: "2026-08-21"
+version: 0.7.1
+date-released: "2026-09-08"
 license: MIT
 repository-code: "https://github.com/PhilanthroPy-Project/PhilanthroPy"
 url: "https://PhilanthroPy-Project.github.io/PhilanthroPy/"

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -89,7 +89,7 @@ Every domain method returns a number on its own scale. None of them are calibrat
 ## Deprecations
 
 !!! info "This page is built from `main`, which is ahead of the release"
-    `pip install philanthropy` currently gives you **0.7.0**. The tier tables
+    `pip install philanthropy` currently gives you **0.7.1**. The tier tables
     above describe the API as it stands on `main`; the deprecations below are
     live in the version you actually have installed.
 
@@ -145,7 +145,7 @@ barely registers.
 If you need per-group behaviour, split the frame by group and fit one imputer per
 part. That is explicit, and it costs nothing that the parameter was buying.
 
-### Live on `main` (0.8.0), removed in 0.9.0
+### Live in 0.7.1, removed in 0.9.0
 
 | Deprecated | Use instead |
 |---|---|

--- a/philanthropy/preprocessing/_share_of_wallet.py
+++ b/philanthropy/preprocessing/_share_of_wallet.py
@@ -454,7 +454,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
            institutional giving in the numerator and total estimated giving in
            the denominator, and this transformer is given neither. Read it as
            "how much of this donor's modelled wealth is estimated to be
-           philanthropic capacity". Until 0.8.0 the column was named
+           philanthropic capacity". Until 0.7.1 the column was named
            ``sow_score``, which claimed a quantity the formula does not
            compute; :meth:`get_legacy_feature_names_out` still spells it that
            way, under a `DeprecationWarning`, until 0.9.0 removes it.
@@ -667,7 +667,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         )
 
     def get_legacy_feature_names_out(self) -> np.ndarray:
-        """Return the pre-0.8.0 output names, ``sow_score`` first.
+        """Return the pre-0.7.1 output names, ``sow_score`` first.
 
         The formula behind column 0 is capacity utilisation, not share of
         wallet, so the column is now named ``capacity_utilisation_ratio``
@@ -689,7 +689,7 @@ class ShareOfWalletScorer(TransformerMixin, BaseEstimator):
         check_is_fitted(self)
         warnings.warn(
             "ShareOfWalletScorer output name 'sow_score' is deprecated since "
-            "0.8.0 and will be removed in 0.9.0; the column measures capacity "
+            "0.7.1 and will be removed in 0.9.0; the column measures capacity "
             "utilisation, not share of wallet. Use "
             "get_feature_names_out(), which reports "
             "'capacity_utilisation_ratio' first.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "philanthropy"
-version = "0.7.0"
+version = "0.7.1"
 description = "scikit-learn-native predictive analytics for nonprofit and academic-medical-center fundraising: donor propensity, lapse, planned giving, wealth screening, and revenue forecasting."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts 0.7.1. Steps 1 to 5 of the RELEASING.md checklist; the tag and the release go on after this merges, and the **Publish release** click stays with the maintainer.

## Why now, and why this is not just housekeeping

Notebooks 02 and 03 import `philanthropy.datasets.make_donor_panel`, which does not exist in the published 0.7.0 wheel. Verified in a clean venv from a neutral cwd, because the repository root shadows site-packages and an earlier check run from the root reported the opposite:

```
$ ./v070/bin/python -c "import philanthropy.datasets as d; print(sorted(d.__all__))"
['fetch_kdd98_donors', 'generate_synthetic_donor_data', 'load_ciob_fundraising']
```

Both notebooks therefore fall into a `try/except ImportError` that pip-installs from `git+...@main`. Two consequences, and the second is the one a JOSS reviewer sees:

1. The fallback cannot work in-process. The failed `from philanthropy.datasets import make_donor_panel` leaves the old module cached in `sys.modules`, so the re-import after a *successful* install raises the same error. It only works where philanthropy is absent entirely, which is fresh Colab. Anyone who followed the README's `pip install philanthropy` and then opened the notebook locally gets a hard failure.
2. The "zero install, try it now" Colab badge runs an unreleased git snapshot rather than the archived release the paper points at.

Releasing is the root-cause fix. The notebook install cells are a separate PR that merges only once 0.7.1 is actually on PyPI, because until then an unconditional `pip install "philanthropy[viz]>=0.7.1"` would break fresh Colab too.

## The version number, which was not obvious

`plan.md` says 0.7.1. The source tree on `main` already said 0.8.0: `_share_of_wallet.py` documented the output rename as "Until 0.8.0 the column was named `sow_score`" and warned "deprecated since 0.8.0", and `docs/reference/index.md` had a "Live on `main` (0.8.0)" heading. The two were written independently and never checked against each other.

The unreleased block is minor-shaped by semver: new public API (`GiftIntervalCalibrator`, `metrics.interval_score`, `metrics.interval_report`, `datasets.make_donor_panel`) plus a renamed output column. None of it is in 0.7.0.

Shipping it as 0.7.1 is a deliberate, documented departure from this project's own versioning policy, taken because the alternative is worse. Cutting 0.8.0 makes three standing promises come due today: removing `WealthScreeningImputerKNN(group_col_idx=...)`, removing `philanthropy.utils.make_donor_dataset`, and flipping the `FiscalYearGroupedSplitter` `drop_repeat_donors` default to `True`. That last one changes the default behaviour of the splitter this package's central argument rests on, six weeks before the merge freeze. Those stay queued for a real 0.8.0.

The mitigation is that the rename is name-only: `ShareOfWalletScorer.transform` column 0 holds the same values in the same position, only `get_feature_names_out()` spells it differently, and `get_legacy_feature_names_out()` returns the old spelling under a `DeprecationWarning` until 0.9.0. Code reading the column positionally needs nothing.

## What changed here

- `pyproject.toml`: `0.7.0` to `0.7.1`. Nothing else carries the runtime version; `philanthropy.__version__` reads installed metadata.
- `CHANGELOG.md`: `## [Unreleased]` becomes `## [0.7.1] - 2026-09-08`, with a fresh empty `## [Unreleased]` above it. `publish.yml` rejects a heading still reading `- TBD`, so the date is load-bearing rather than cosmetic.
- `CHANGELOG.md` heading cleanup, which is RELEASING step 1 doing its job. `.gitattributes` sets `merge=union` on this file so concurrent PRs stop conflicting, and the cost is that git will never flag a problem in it again. The union driver had left the unreleased block with four `### Added` headings, two `### Fixed`, two `### Changed` and two `### Deprecated`. Collapsed to one of each in Keep a Changelog order. No bullet text was edited and none was dropped.
- One bullet moved section: the #194 refactor was filed under `### Fixed`, and a deduplication with no behaviour change belongs under `### Changed`. Union merges are line-based, not section-aware, which is exactly the failure mode RELEASING step 1 says to eyeball for.
- `CITATION.cff`: `version` and `date-released`. The file's own comment says `version` tracks the newest published release, and the tag will point at this commit, so the archived citation has to name 0.7.1 rather than the release before it.
- `_share_of_wallet.py` and `docs/reference/index.md`: the four strings that described the rename as arriving in 0.8.0 now say 0.7.1, including the live `DeprecationWarning` text users actually read. Every *future* promise still says 0.8.0 and is untouched: `group_col_idx`, `utils.make_donor_dataset`, and the `drop_repeat_donors` default. `tests/test_deprecations.py` stores removal versions only and `test_sow_score_still_works_and_warns` matches on "removed in 0.9.0", so no test needed changing.
- `docs/reference/index.md` also stops telling readers that `pip install philanthropy` gives them 0.7.0.

## Not in this PR, on purpose

- `SECURITY.md` already supports `0.7.x`, so 0.7.1 needs no edit there.
- `.zenodo.json` carries no version field; Zenodo reads it at deposit time.
- The `### Removed in 0.7.0` section of the deprecations page stays as it is. Those removals did happen in 0.7.0.
- `## [1.0.0] - TBD` is left exactly where it sits. It is staged, not being cut, and the publish gate compares the tag against the `pyproject.toml` of the commit the tag points at, so its presence changes nothing.

## Verification

Run locally against the editable install, after reinstalling so the metadata version matches the bumped `pyproject.toml`:

```
python -m pip install -e ".[dev]"
python -c "from importlib.metadata import version; print(version('philanthropy'))"   # 0.7.1
make ci
make riskcov
python -m build && python -m twine check --strict dist/*
```

Output pasted in a comment below.
