### PR TITLE
test: cover both unchecked get_feature_names_out call shapes, fix the CRMCleaner crash they found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+- `CRMCleaner.get_feature_names_out` raised `AttributeError: 'CRMCleaner' object
+  has no attribute 'feature_names_in_'` when the transformer had been fitted on
+  an unnamed array. `check_is_fitted` passed, because `n_features_in_` was set,
+  and the next line then read an attribute that scikit-learn only assigns when
+  the input carried column names. It now falls back to `x0`, `x1`, ... for an
+  array fit, matching what `WealthScreeningImputer` and `WealthScreeningImputerKNN`
+  already did. Closes #157.
+
+### Added
+- `tests/test_public_api_contract.py` gains two contracts over every public
+  transformer, covering the two `get_feature_names_out` call shapes the suite
+  never exercised. It previously only ever called `get_feature_names_out()` with
+  no argument on a DataFrame-fitted transformer.
+  `test_feature_names_out_accepts_input_features` passes the real column names
+  through, which is the call `ColumnTransformer` and `Pipeline.get_feature_names_out`
+  actually make, and `test_feature_names_out_width_after_array_fit` fits on an
+  unnamed array. The second one is what caught the `CRMCleaner` defect above.
+  Transformers that genuinely cannot fit on an unnamed array are listed in a new
+  `_EXEMPT_ARRAY_FIT` table with a written reason each: `EncounterTransformer`
+  merges on a named `donor_id`, and `MatchingGiftFeaturizer` rejects a
+  non-DataFrame outright. That table is kept separate from `_EXEMPT` on purpose,
+  because folding these two into `_EXEMPT` would also have dropped them from the
+  width and `input_features` checks they do pass. Three hygiene tests police it:
+  no stale entry, no name in both tables, and a reason on every entry in both.
+
 ## [0.7.1] - 2026-09-08
 
 ### Added

--- a/philanthropy/preprocessing/_transformers.py
+++ b/philanthropy/preprocessing/_transformers.py
@@ -218,7 +218,7 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
         ----------
         input_features : array-like of str or None, default=None
             Ignored. The output names are the input column names recorded by
-            :meth:`fit`.
+            :meth:`fit`, or ``x0``, ``x1``, ... when fitted on an unnamed array.
 
         Returns
         -------
@@ -231,7 +231,10 @@ class CRMCleaner(TransformerMixin, BaseEstimator):
             If the transformer has not been fitted.
         """
         check_is_fitted(self)
-        names = list(self.feature_names_in_)
+        if hasattr(self, "feature_names_in_"):
+            names = list(self.feature_names_in_)
+        else:
+            names = [f"x{i}" for i in range(self.n_features_in_)]
         return np.array(names, dtype=object)
 
     def __sklearn_tags__(self) -> Tags:

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -11,7 +11,12 @@ Introspection only: no fixtures, no data files. It asserts four things:
    callable with X alone, and returns a 1-D ndarray of ``len(X)``.
 3. Every ``preprocessing.__all__`` class defines its own
    ``get_feature_names_out(self, input_features=None)`` whose length equals
-   ``transform(X).shape[1]``.
+   ``transform(X).shape[1]``, in three call shapes: no argument after a
+   DataFrame fit, ``input_features=`` after a DataFrame fit (the call
+   ``ColumnTransformer`` and ``Pipeline.get_feature_names_out`` make), and no
+   argument after an unnamed-array fit. Transformers that cannot fit on an
+   unnamed array at all are listed in ``_EXEMPT_ARRAY_FIT``, separately from
+   ``_EXEMPT``, because they still have to honour the other two shapes.
 4. ``philanthropy.__all__`` covers every non-underscore subpackage directory, so
    a new subpackage cannot ship unreachable.
 
@@ -64,6 +69,24 @@ _EXEMPT = {
         "cls(**kwargs) and fitted on one array pair; and "
         "predict_gift_interval returns a GiftInterval carrying two bounds plus "
         "the attained level, not a single value per row."
+    ),
+}
+
+# Exemptions for the unnamed-array fit only. Deliberately separate from
+# _EXEMPT: a transformer that looks its columns up by name still has to honour
+# every other contract, and folding these into _EXEMPT would silently drop it
+# from the width and input_features checks too. Same discipline applies, one
+# written reason each, and test_every_exemption_carries_a_reason covers both.
+_EXEMPT_ARRAY_FIT = {
+    "EncounterTransformer": (
+        "Merges an encounter table onto X by name and raises a written "
+        "ValueError naming `merge_key` when the column is absent. An unnamed "
+        "array has no donor_id to merge on, so there is nothing to fit."
+    ),
+    "MatchingGiftFeaturizer": (
+        "Rejects a non-DataFrame X outright with `TypeError: X must be a "
+        "pandas DataFrame`: it reads the employer column by name and there is "
+        "no positional equivalent."
     ),
 }
 
@@ -299,6 +322,48 @@ def test_feature_names_out_width_matches_transform(name):
     )
 
 
+@pytest.mark.parametrize("name", sorted(preprocessing.__all__))
+def test_feature_names_out_accepts_input_features(name):
+    if name in _EXEMPT:
+        pytest.skip(_EXEMPT[name])
+
+    est = _transformer_instance(name)
+    X = _transformer_input(name)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = est.fit_transform(X)
+        names = est.get_feature_names_out(input_features=list(X.columns))
+
+    width = out.shape[1]
+    assert len(names) == width, (
+        f"{name}.get_feature_names_out(input_features=...) has {len(names)} "
+        f"names but transform produced {width} columns. ColumnTransformer and "
+        f"Pipeline both pass input_features down explicitly, so this is the "
+        f"call shape a real pipeline makes."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(preprocessing.__all__))
+def test_feature_names_out_width_after_array_fit(name):
+    if name in _EXEMPT:
+        pytest.skip(_EXEMPT[name])
+    if name in _EXEMPT_ARRAY_FIT:
+        pytest.skip(_EXEMPT_ARRAY_FIT[name])
+
+    est = _transformer_instance(name)
+    X = _transformer_input(name).to_numpy()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = est.fit_transform(X)
+        names = est.get_feature_names_out()
+
+    width = out.shape[1]
+    assert len(names) == width, (
+        f"{name} fitted on an unnamed array: get_feature_names_out() has "
+        f"{len(names)} names but transform produced {width} columns"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Exemption hygiene
 # ---------------------------------------------------------------------------
@@ -309,9 +374,31 @@ def test_no_exemption_is_stale():
     assert not unknown, f"_EXEMPT names symbols that are no longer public: {unknown}"
 
 
+def test_no_array_fit_exemption_is_stale():
+    unknown = sorted(set(_EXEMPT_ARRAY_FIT) - set(preprocessing.__all__))
+    assert not unknown, (
+        f"_EXEMPT_ARRAY_FIT names symbols that are no longer public "
+        f"transformers: {unknown}"
+    )
+
+
+def test_no_exemption_is_listed_twice():
+    both = sorted(set(_EXEMPT) & set(_EXEMPT_ARRAY_FIT))
+    assert not both, (
+        f"{both} are in both _EXEMPT and _EXEMPT_ARRAY_FIT. _EXEMPT already "
+        f"skips every check, so the array-fit entry is dead weight that will "
+        f"outlive the reason written next to it."
+    )
+
+
 def test_every_exemption_carries_a_reason():
-    for name, reason in _EXEMPT.items():
-        assert len(reason) > 40, f"{name}'s exemption reason is not an explanation"
+    for table, name, reason in (
+        [("_EXEMPT", n, r) for n, r in _EXEMPT.items()]
+        + [("_EXEMPT_ARRAY_FIT", n, r) for n, r in _EXEMPT_ARRAY_FIT.items()]
+    ):
+        assert len(reason) > 40, (
+            f"{name}'s {table} reason is not an explanation"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #157.

## What the issue predicted, and what actually happened

The issue said the value would be "the transformers this finds, not the two tests," and to report it either way. It found one real defect and cleared the rest.

**Found: `CRMCleaner.get_feature_names_out` crashes after an unnamed-array fit.**

```
AttributeError: 'CRMCleaner' object has no attribute 'feature_names_in_'
```

`check_is_fitted(self)` passes, because `n_features_in_` is set, and the next line then reads `self.feature_names_in_`, which scikit-learn only assigns when the fitted input carried column names. So the failure lands one line after the guard that is supposed to catch exactly this class of problem, and it surfaces as an `AttributeError` rather than anything a caller can handle.

The fix is the fallback `WealthScreeningImputer` and `WealthScreeningImputerKNN` already had, and nothing else:

```python
if hasattr(self, "feature_names_in_"):
    names = list(self.feature_names_in_)
else:
    names = [f"x{i}" for i in range(self.n_features_in_)]
```

Before and after, on the same fixture:

```
named  -> ['gift_date', 'gift_amount']
array  -> AttributeError        # was
array  -> ['x0', 'x1']          # now
widths -> 2 2
```

**Cleared: `input_features` is honoured everywhere it is claimed to be.** All 13 non-exempt public transformers already return the right width when passed `input_features=list(X.columns)`. Zero failures. That is a real result and worth stating rather than leaving as an absence.

## The two new contracts

Both parametrize over `sorted(preprocessing.__all__)` and reuse the existing `_transformer_instance` / `_transformer_input` helpers, so there is no second fixture table to drift against `__all__`.

- `test_feature_names_out_accepts_input_features`: fits on the DataFrame, then passes the real column names. This is the call `ColumnTransformer` and `Pipeline.get_feature_names_out` actually make, and nothing in the suite made it before.
- `test_feature_names_out_width_after_array_fit`: fits on `X.to_numpy()`. This is what caught `CRMCleaner`.

## One deliberate deviation from the issue text

The issue says to add array-fit failures to `_EXEMPT`. I put them in a separate `_EXEMPT_ARRAY_FIT` instead, because `_EXEMPT` skips *every* check: folding these two in would also have dropped them from the width and `input_features` contracts, which they both pass. Losing two passing contracts to record one legitimate limitation is a bad trade, and it would have been invisible.

Two entries, one written reason each, same discipline as `_EXEMPT`:

- `EncounterTransformer` merges an encounter table on a named `donor_id` and raises a written `ValueError` naming `merge_key` when it is absent.
- `MatchingGiftFeaturizer` rejects a non-DataFrame outright with `TypeError: X must be a pandas DataFrame`.

Three hygiene tests police the new table so it cannot rot: no stale entry, no name in both tables, and a reason on every entry in both.

## Follow-up question, deliberately not changed here

`CRMCleaner.get_feature_names_out` documents `input_features` as "Ignored", and `FiscalYearTransformer` and `ShareOfWalletScorer` likewise return fixed arrays regardless of what is passed. scikit-learn's own convention is to validate `input_features` against `feature_names_in_` and raise on a mismatch. Ignoring it means a caller who passes the wrong names silently gets the wrong answer instead of an error.

That is a behaviour change, not a bug fix, so per the issue's own instruction it is flagged rather than shipped inside this PR. Worth its own issue if you agree; defensible as-is for the two fixed-output transformers, less so for `CRMCleaner`.

## Verification

```
python -m pytest tests/test_public_api_contract.py -q      # 109 passed
python -m pytest tests/ --cov=philanthropy -q              # 2003 passed, 8 skipped, 98.18%
make ci
make riskcov
```

The behavioural check above is the direct evidence for the fix: the array-fit call raised before the change and returns `['x0', 'x1']` after it.
