### PR TITLE
fix: surface invalid encounter timezone errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Fixed
+- `EncounterRecencyTransformer` no longer catches timezone conversion errors
+  and retries with `tz_localize` after parsing with `utc=True`. The retry was
+  unreachable for valid timezone inputs and replaced the useful
+  `UnknownTimeZoneError` for invalid timezone names with a misleading
+  "Already tz-aware" error. Closes #201.
 - `CRMCleaner.get_feature_names_out` raised `AttributeError: 'CRMCleaner' object
   has no attribute 'feature_names_in_'` when the transformer had been fitted on
   an unnamed array. `check_is_fitted` passed, because `n_features_in_` was set,

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,6 +66,10 @@ contribution. Code, docs, tests, and review all count.
   fallback with its `general` category and added regression coverage for
   missing service-line and physician columns (closes
   [#151](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/151)).
+- [@Utkarsh3725](https://github.com/Utkarsh3725): removed the unreachable
+  timezone-localisation fallback in `EncounterRecencyTransformer`, preserving
+  the useful invalid-timezone error (closes
+  [#201](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/201)).
 
 ## Getting listed
 

--- a/philanthropy/preprocessing/_encounter_recency.py
+++ b/philanthropy/preprocessing/_encounter_recency.py
@@ -193,11 +193,8 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         """Parse a date series to datetime64[ns], optionally localising timezone."""
         parsed = pd.to_datetime(series, errors="coerce", utc=(self.timezone is not None))
         if self.timezone is not None:
-            # Convert to the target timezone; if already tz-aware, convert.
-            try:
-                parsed = parsed.dt.tz_convert(self.timezone)
-            except Exception:
-                parsed = parsed.dt.tz_localize(self.timezone)
+            # utc=True above already makes parsed dates tz-aware.
+            parsed = parsed.dt.tz_convert(self.timezone)
         return parsed
 
     def _fiscal_year(self, dt: pd.Timestamp) -> int:


### PR DESCRIPTION
## What & why

  Removes the unreachable `tz_localize` fallback in `EncounterRecencyTransformer._parse_dates`.

  When `timezone` is set, `pd.to_datetime(..., utc=True)` already returns timezone-aware parsed dates, so `tz_convert()` is the correct path. The old broad `except Exception` fallback only made invalid
  timezone errors worse by replacing the useful timezone error with a misleading "Already tz-aware" error.

  Closes #201.

  ## Checklist

  - [ ] `make ci` passes locally (lint -> collection -> tests -> coverage >= 92%)
  - [ ] New/changed public API has docstrings and is exported in the subpackage `__init__.py`
  - [x] Tests added or updated
  - [x] `CHANGELOG.md` updated under `[Unreleased]`
  - [x] Added yourself to `CONTRIBUTORS.md`

  ## Testing

  - [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_encounter_timezone.py tests/test_preprocessing.py -q`
    - Result: 68 passed
  - [x] `.venv/bin/python -m flake8 philanthropy/preprocessing/_encounter_recency.py`

  I could not run the coverage version locally because pytest coverage hit a local NumPy import-loader issue in this environment before collecting tests. The focused behavior tests pass.

