### PR TITLE
docs: cite the Zenodo preprint DOI in paper.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - `paper.md`'s Research impact statement now cites the leakage preprint,
   archived on Zenodo as DOI `10.5281/zenodo.22665386`, alongside the real-data
   replication archive it already cited. `paper.bib` gains the matching
-  `leakagepreprint2026` entry. Part of #127.
+  `leakagepreprint2026` entry. The same statement's external-contribution
+  count was stale and understated: it now reads thirty-five merged pull
+  requests from eleven contributors external to the project, measured from the
+  merged-PR list rather than recalled. Part of #127.
 
 ### Fixed
 - `EncounterRecencyTransformer` no longer catches timezone conversion errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- `paper.md`'s Research impact statement now cites the leakage preprint,
+  archived on Zenodo as DOI `10.5281/zenodo.22665386`, alongside the real-data
+  replication archive it already cited. `paper.bib` gains the matching
+  `leakagepreprint2026` entry. Part of #127.
+
 ### Fixed
 - `CRMCleaner.get_feature_names_out` raised `AttributeError: 'CRMCleaner' object
   has no attribute 'feature_names_in_'` when the transformer had been fitted on

--- a/paper.bib
+++ b/paper.bib
@@ -186,3 +186,14 @@
   note         = {Archived reproducible materials: the experiment script,
     its unedited output, and an environment lock}
 }
+
+@misc{leakagepreprint2026,
+  title        = {Auxiliary-table timing, not splitter choice, dominates leakage
+    in donor propensity models: evidence from synthetic and real fundraising panels},
+  author       = {Lalakiya, Shivam Ashokbhai},
+  year         = {2026},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.22665386},
+  note         = {Preprint. Reports the synthetic donor-year panel and the
+    {KDD Cup 1998} replication together}
+}

--- a/paper.md
+++ b/paper.md
@@ -174,8 +174,8 @@ separately on Zenodo with its own DOI [@kddcup1998replicationzenodo], a
 preprint reporting both experiments together, archived on Zenodo with its own
 DOI [@leakagepreprint2026], a benchmark page that states its own synthetic-data
 limitations and the Bayes-optimal ceiling of its generator, an archived release
-on Zenodo, and eleven merged pull requests from four contributors external to
-the project.
+on Zenodo, and thirty-five merged pull requests from eleven contributors
+external to the project.
 The author's prior conference paper on predictive donor analytics
 [@lalakiya2025] is related work by the same author on
 different data, not an independent evaluation of this software.

--- a/paper.md
+++ b/paper.md
@@ -171,9 +171,11 @@ reproducible leakage experiment whose result is reported above and now
 replicated on real donor data (KDD Cup 1998 [@kddcup1998]) rather than only on
 a synthetic generator, with its script output and environment archived
 separately on Zenodo with its own DOI [@kddcup1998replicationzenodo], a
-benchmark page that states its own synthetic-data limitations and the
-Bayes-optimal ceiling of its generator, an archived release on Zenodo, and
-eleven merged pull requests from four contributors external to the project.
+preprint reporting both experiments together, archived on Zenodo with its own
+DOI [@leakagepreprint2026], a benchmark page that states its own synthetic-data
+limitations and the Bayes-optimal ceiling of its generator, an archived release
+on Zenodo, and eleven merged pull requests from four contributors external to
+the project.
 The author's prior conference paper on predictive donor analytics
 [@lalakiya2025] is related work by the same author on
 different data, not an independent evaluation of this software.


### PR DESCRIPTION
The preprint reporting the synthetic and real-data leakage experiments is published on Zenodo: <https://doi.org/10.5281/zenodo.22665386> (recid 22665386, concept 10.5281/zenodo.22665385, CC-BY-4.0, resource type Publication/Preprint). Its related identifiers cite the software DOI `10.5281/zenodo.22050896` and the replication archive `10.5281/zenodo.22050649`, and mark it a supplement to this repository, so the paper and the preprint point at each other.

JOSS's `submitting.html` asks for "publications, preprints, or documented use" and adds that aspirational statements about future use are not sufficient. `paper.md`'s Research impact statement now cites the preprint alongside the replication archive it already cited, and `paper.bib` gains the matching `leakagepreprint2026` entry.

Context: MetaArXiv rejected the same manuscript on 2026-09-08 as "Outside of the scope of this preprint series" and minted no DOI, so the Zenodo record is the only citable version. Nothing anywhere should cite `10.31222/osf.io/qay8j`; it does not exist.

- `paper.md` word count is 1,597 against the 1,750 ceiling.
- No source, test, or packaging change; the diff is the paper, its bibliography, and the changelog.
- Part of #127.

---

**Added after review:** the same paragraph claimed "eleven merged pull requests from four contributors external to the project". Measured from the merged-PR list, the real figures are **thirty-five merged pull requests from eleven contributors** external to the project (40 external PRs from 12 accounts, minus Dependabot's 5; all 35 merged into `main`). Understating community contribution three-fold in the section JOSS reads for exactly that is worth correcting here rather than in a separate PR, and the replacement is the same number of words, so the count stays at 1,597.

Note `plan.md`'s "33 merged PRs from 10 external humans" is now stale for the same reason; it predates #194 and #202.

**This does not close #116.** The 35-from-11 figure is accurate as of the merge date and will go stale again before 2026-10-26; there are five weeks of merges and an active good-first-issue funnel between now and then. The submission-day re-measurement of this sentence stays required: #116 stays open, and `plan.md`'s two unchecked submission-day items for it stay unchecked. This PR only stops a three-fold understatement from sitting in the paper for seven weeks; it does not replace the submission-day pass.
