### PR TITLE
docs: give seven high-intent pages their own meta description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Changed
+- Seven high-intent documentation pages now carry a per-page `description` in
+  YAML front matter, so a search result or social card shows that page's own
+  summary rather than the site-wide `site_description`. The first-model
+  tutorial is retitled "Building Your First Donor Propensity Model in Python";
+  the previous "Building Your First Model" named neither the domain nor the
+  language, and MkDocs derives the nav label from the first heading, so the
+  entry was equally opaque there. Every description is quoted: an unquoted YAML
+  scalar containing a colon and a space parses as a nested mapping, which
+  silently drops the `<meta name="description">` tag and renders the front
+  matter as visible page text instead.
 - `paper.md`'s Research impact statement now cites the leakage preprint,
   archived on Zenodo as DOI `10.5281/zenodo.22665386`, alongside the real-data
   replication archive it already cited. `paper.bib` gains the matching

--- a/docs/explanation/comparison_to_vendors.md
+++ b/docs/explanation/comparison_to_vendors.md
@@ -1,3 +1,7 @@
+---
+description: "How an open-source donor scoring library compares with commercial wealth-screening vendors, including when a vendor is the better call."
+---
+
 # PhilanthroPy vs. Commercial Vendors
 
 Most advancement shops already pay for a wealth-screening or predictive-modeling

--- a/docs/explanation/fundraising_metrics.md
+++ b/docs/explanation/fundraising_metrics.md
@@ -1,3 +1,7 @@
+---
+description: "Lifetime value, efficiency and ROI metrics for fundraising analytics, and how PhilanthroPy computes each one."
+---
+
 # Fundraising metrics
 
 Accuracy and R-Squared measure a model. They don't measure whether fundraising worked. PhilanthroPy provides metrics that speak the language of development officers and CFOs.

--- a/docs/explanation/real_data_replication.md
+++ b/docs/explanation/real_data_replication.md
@@ -1,3 +1,7 @@
+---
+description: "Replicated on 95,412 real donors: whole-history features inflate walk-forward ROC-AUC from 0.482 to 0.858, roughly three times the synthetic effect."
+---
+
 # Real-Data Replication: KDD Cup 1998
 
 Everything else this project measures is synthetic. This page is not.

--- a/docs/how-to/handle_missing_wealth_data.md
+++ b/docs/how-to/handle_missing_wealth_data.md
@@ -1,3 +1,7 @@
+---
+description: "Impute missing wealth-screening fields without leaking test data: WealthScreeningImputer freezes per-column training medians in fit."
+---
+
 # Handle missing wealth data
 
 Third-party wealth vendors rarely match every record in a database. This guide shows you how to fill the gaps without leaking information from your test set into training.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+description: "scikit-learn estimators for nonprofit and hospital fundraising analytics: donor propensity, lapse risk, wealth-screening imputation, leakage-safe by design."
+---
+
 <div class="ap-hero" markdown>
 <span class="ap-hero__eyebrow">Open source · scikit-learn native</span>
 

--- a/docs/tutorials/avoiding_temporal_data_leakage.md
+++ b/docs/tutorials/avoiding_temporal_data_leakage.md
@@ -1,3 +1,7 @@
+---
+description: "How temporal leakage inflates donor model backtests and how as-of feature timing prevents it, measured at +0.376 ROC-AUC on real campaign data."
+---
+
 # Avoiding temporal data leakage in fundraising models
 
 Predicting major gifts or donor retention carries one common trap: **temporal data leakage**, using information from the future to predict an outcome in the past. PhilanthroPy's transformers and models are leakage-safe by design.

--- a/docs/tutorials/avoiding_temporal_data_leakage.md
+++ b/docs/tutorials/avoiding_temporal_data_leakage.md
@@ -1,5 +1,5 @@
 ---
-description: "How temporal leakage inflates donor model backtests and how as-of feature timing prevents it, measured at +0.376 ROC-AUC on real campaign data."
+description: "How temporal leakage inflates donor model backtests, and how as-of feature timing in PhilanthroPy's transformers and models prevents it."
 ---
 
 # Avoiding temporal data leakage in fundraising models

--- a/docs/tutorials/building_your_first_model.md
+++ b/docs/tutorials/building_your_first_model.md
@@ -1,4 +1,8 @@
-# Building Your First Model
+---
+description: "Build a donor propensity model in Python with scikit-learn: load donor data, fit DonorPropensityModel, and produce affinity scores a gift officer can act on."
+---
+
+# Building Your First Donor Propensity Model in Python
 
 Build a working machine learning pipeline with PhilanthroPy and scikit-learn. You start with raw donor data and finish with affinity scores a gift officer can act on.
 


### PR DESCRIPTION
## What this fixes

MkDocs Material falls back to `site_description` when a page carries no `description` of its own. Every page in the built site therefore advertised the same generic sentence, so a search result or a shared link pointing at the leakage tutorial said nothing about leakage.

Seven pages now carry a per-page `description` in front matter:

| Page | Targets |
|---|---|
| `docs/index.md` | the landing page |
| `docs/tutorials/building_your_first_model.md` | "donor propensity model python" |
| `docs/tutorials/avoiding_temporal_data_leakage.md` | "as-of feature timing", "temporal leakage donor data" |
| `docs/explanation/real_data_replication.md` | the +0.376 AUC result |
| `docs/how-to/handle_missing_wealth_data.md` | wealth-screening imputation |
| `docs/explanation/comparison_to_vendors.md` | open source vs commercial screening |
| `docs/explanation/fundraising_metrics.md` | lifetime value, efficiency, ROI |

The first-model tutorial is also retitled from "Building Your First Model" to "Building Your First Donor Propensity Model in Python". MkDocs derives the nav label from the first heading, so the old title was equally opaque in the sidebar.

## One gotcha worth knowing, because it fails silently

Every description is quoted. An unquoted YAML scalar containing a colon and a space parses as a nested mapping. There is no error: MkDocs drops the `<meta name="description">` tag, falls back to `site_description`, and renders the front matter as visible text at the top of the page. Four of the seven descriptions contained one (`analytics: donor propensity`, `scikit-learn: load donor data`), and it was only visible by grepping the built HTML.

## Verification

- `mkdocs build --strict` clean
- All seven pages emit distinct `<meta name="description">` in the built HTML; zero front-matter leaks into rendered text
- `make ci` exit 0; total coverage 98% against the 92 floor in `pyproject.toml`; `make riskcov` 98% against 93
- `WealthScreeningImputer freezes per-column training medians in fit` was checked before going into a public tag: `fill_values_` is assigned in `fit` at `philanthropy/preprocessing/_wealth.py:251` and only read in `transform` after `check_is_fitted`

## Scope, stated honestly

This is the findability half only. A per-page description changes the snippet a search engine shows once a page ranks; it does not make a page rank. The content half is tracked separately:

- The leakage tutorial carries no measured result at all and does not link `explanation/real_data_replication.md`. Filed as #205 for an external contributor.
- A page that answers "how do I build a donor propensity model in Python" before it names this library does not exist yet. Planned for week 38, so it lands in a week that currently has zero merges against the pace floor rather than pushing week 37 to its cap.
