### PR TITLE
fix: enforce the as-of cutoff on the gift-side roll-up, with the attributed real leakage case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- `RFMTransformer` gains an `as_of` parameter. Gifts dated after it are dropped
+  before the roll-up, so `frequency` and `monetary` describe only what had
+  happened by the scoring date. The gift-side roll-up was the one feature
+  builder that did not enforce the cutoff the clinical-encounter builders
+  already did: with `reference_date` set and a gift table running past it,
+  `monetary` silently summed gifts from after the date being scored and
+  `recency` went negative. Left at the default `None` the behaviour is
+  unchanged, but it now warns instead of aggregating the future silently.
+  Closes #208.
+
 ### Changed
 - `paper.md`'s Research impact statement now cites the leakage preprint,
   archived on Zenodo as DOI `10.5281/zenodo.22665386`, alongside the real-data
@@ -13,6 +24,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   count was stale and understated: it now reads thirty-five merged pull
   requests from eleven contributors external to the project, measured from the
   merged-PR list rather than recalled. Part of #127.
+- The leakage tutorial's opening example is now a real one, contributed and
+  attributed with permission: Marianne Pelletier's new-donor model built on a
+  lifetime-giving-greater-than-zero variable, where the feature was the
+  outcome. It replaces the synthetic `total_lifetime_giving` sketch and gains a
+  runnable `as_of` walkthrough of the same failure. Closes #209.
 
 ### Fixed
 - `EncounterRecencyTransformer` no longer catches timezone conversion errors

--- a/docs/tutorials/avoiding_temporal_data_leakage.md
+++ b/docs/tutorials/avoiding_temporal_data_leakage.md
@@ -6,7 +6,40 @@ This tutorial shows how temporal leakage happens and how PhilanthroPy prevents i
 
 ## The problem: naive aggregation
 
-Say you build a feature `total_lifetime_giving` and attach it to historical snapshots of each donor. If you use the final, present-day `total_lifetime_giving` value to predict whether a donor gave a major gift three years ago, you have trained the model on the future.
+Marianne Pelletier of Staupell Analytics Group describes the sharpest version of it, from her own modelling work:
+
+> I once modeled new donors with the 100% correlated variable of their having a greater than 0 lifetime giving total!
+
+The feature was the outcome. Validation looked perfect and the field did not, because a prospective new donor's lifetime giving is 0 as of the scoring date: cut to that date the feature goes constant rather than perfect. Her prescription is the rule this library enforces, roll-up variables that count up to the day before the event. She puts it as modelling baseball, where you build the stats that were true the day before the game and model on those. (Quoted with her permission.)
+
+The same trap catches any feature built by aggregating a source table that runs past the outcome: a `total_lifetime_giving` attached to historical donor snapshots, a wealth-capacity field refreshed to today's value, a clinical encounter that had not happened yet.
+
+## The cutoff: `as_of`
+
+The three roll-up transformers, `RFMTransformer`, `EncounterTransformer` and `GratefulPatientFeaturizer`, take an `as_of` date and drop every source row dated after it *before* any roll-up is computed. `RFMTransformer` rolls a gift log up to one row per donor, so it is where Pelletier's case lands:
+
+```python
+import pandas as pd
+from philanthropy.preprocessing import RFMTransformer
+
+gifts = pd.DataFrame({
+    'donor_id': [1, 1, 1],
+    'gift_date': ['2020-01-01', '2021-01-01', '2025-01-01'],
+    'gift_amount': [100.0, 100.0, 50_000.0],
+})
+
+# Scoring as of 2022: the 2025 gift had not been given yet.
+rfm = RFMTransformer(reference_date='2022-01-01', as_of='2022-01-01')
+print(rfm.fit_transform(gifts))
+#    donor_id  recency  frequency  monetary
+# 0         1      365          2      200.0
+```
+
+`as_of` is inclusive, so to get Pelletier's day-before rule exactly, pass the day before the outcome you are predicting: `as_of=D` still rolls a gift made on `D` into `monetary`.
+
+Leave `as_of` unset while the gift table runs past the reference date and the transformer warns rather than quietly aggregating the future. Without the cutoff the same donor rolls up to `frequency=3`, `monetary=50200.0` and a *negative* recency of -1096 days: the model is being told about a gift from three years after the date it is scoring.
+
+`EncounterTransformer` and `GratefulPatientFeaturizer` take the same `as_of` argument for clinical encounter tables. Transformers that read a dated table without rolling it up, such as `EncounterRecencyTransformer`, have no cutoff: restrict their input yourself.
 
 ## The solution: fit-time snapshots
 
@@ -53,3 +86,4 @@ features_test = transformer.transform(donor_df_test)
 1. **Split first**: Split your data into training and test sets *before* passing them to a pipeline.
 2. **Use pipelines**: Wrap your transformers inside a `sklearn.pipeline.Pipeline`.
 3. **Use temporal splits**: For time-series data like fundraising, reach for `FiscalYearGroupedSplitter` (see the CV documentation) so test folds fall strictly after training folds in time.
+4. **Set `as_of`**: Pass the end of your training window to `RFMTransformer`, `EncounterTransformer` and `GratefulPatientFeaturizer`. Cross-validation cannot catch a leak that happens inside one donor's roll-up.

--- a/philanthropy/preprocessing/_encounters.py
+++ b/philanthropy/preprocessing/_encounters.py
@@ -60,13 +60,18 @@ _Self = TypeVar("_Self", bound="EncounterTransformer")
 
 
 def _apply_as_of_cutoff(
-    enc: pd.DataFrame, discharge_col: str, as_of: Any, class_name: str
+    enc: pd.DataFrame,
+    discharge_col: str,
+    as_of: Any,
+    class_name: str,
+    row_noun: str = "encounter",
 ) -> pd.DataFrame:
-    """Drop encounter rows discharged after ``as_of``.
+    """Drop rows dated after ``as_of``.
 
-    Returns ``enc`` unchanged when ``as_of`` is ``None``. Rows whose discharge
-    date did not parse are kept, so each caller keeps its own rule for those and
-    the cutoff cannot silently change it.
+    Returns ``enc`` unchanged when ``as_of`` is ``None``. Rows whose date did
+    not parse are kept, so each caller keeps its own rule for those and the
+    cutoff cannot silently change it. ``row_noun`` names the rows in the
+    warning text; the gift-side callers pass ``"gift"``.
     """
     if as_of is None:
         return enc
@@ -83,9 +88,10 @@ def _apply_as_of_cutoff(
     keep = enc[discharge_col].isna() | (enc[discharge_col] <= cutoff)
     if not keep.any() and len(enc):
         warnings.warn(
-            f"{class_name}(as_of={cutoff.date()}) excluded every encounter row, "
-            "so the summary is empty and every donor scores as having no "
-            "encounters. Check that as_of is later than your encounter history.",
+            f"{class_name}(as_of={cutoff.date()}) excluded every {row_noun} "
+            f"row, so the summary is empty and every donor scores as having no "
+            f"{row_noun}s. Check that as_of is later than your {row_noun} "
+            "history.",
             UserWarning,
         )
     return enc[keep]

--- a/philanthropy/preprocessing/_rfm.py
+++ b/philanthropy/preprocessing/_rfm.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, TypeVar
 
 import numpy as np
@@ -7,6 +8,8 @@ import pandas as pd
 from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted
+
+from ._encounters import _apply_as_of_cutoff
 
 _Self = TypeVar("_Self", bound="RFMTransformer")
 
@@ -33,6 +36,15 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
     agg_func : str or callable, default='sum'
         The aggregation function to calculate the monetary value. 
         Typical values are 'sum' (cumulative) or 'mean' (average).
+    as_of : str, datetime-like or None, default=None
+        Scoring-date cutoff. Gifts dated after ``as_of`` are dropped before any
+        roll-up, so ``frequency`` and ``monetary`` describe only what had
+        happened by that date. Left at ``None`` the whole gift table is
+        aggregated, which inflates the roll-up with gifts that postdate the
+        decision being modelled: the classic case is a new-donor model whose
+        cumulative-giving feature is really the outcome. ``None`` warns rather
+        than silently aggregating the future whenever the table runs past the
+        frozen reference date.
     include_tenure : bool, default=False
         Emit a fifth column, ``tenure``: days from the donor's *first* gift to
         the frozen reference date. Recency-frequency-monetary alone cannot feed
@@ -46,10 +58,12 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
         reference_date: Any = None,
         agg_func: Any = 'sum',
         include_tenure: bool = False,
+        as_of: Any = None,
     ) -> None:
         self.reference_date = reference_date
         self.agg_func = agg_func
         self.include_tenure = include_tenure
+        self.as_of = as_of
 
     def fit(self: _Self, X: Any, y: Any = None) -> _Self:
         """
@@ -69,13 +83,15 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
         # Freeze the recency reference date from TRAINING data (leakage-safety
         # contract: fitted statistics are computed in fit and frozen before
         # transform). Mirrors EncounterRecencyTransformer.reference_date_.
+        # Cut in fit as well as transform, so an unparseable as_of is caught
+        # where every other parameter is validated, and so an unset
+        # reference_date falls on the last gift the as_of window allows rather
+        # than the last gift on file.
+        X_cut = self._cut(X)
         if self.reference_date is not None:
             self.reference_date_ = pd.to_datetime(self.reference_date)
         else:
-            X_df = X if hasattr(X, "columns") else pd.DataFrame(
-                X, columns=self.feature_names_in_
-            )
-            self.reference_date_ = pd.to_datetime(X_df["gift_date"]).max()
+            self.reference_date_ = X_cut["gift_date"].max()
         return self
 
     def transform(self, X: Any) -> pd.DataFrame:
@@ -88,8 +104,8 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
         # Manual validation
         self._validate_input(X)
         
-        X_df = X.copy() if hasattr(X, "columns") else pd.DataFrame(X, columns=self.feature_names_in_)
-        X_df['gift_date'] = pd.to_datetime(X_df['gift_date'])
+        X_df = self._cut(X)
+        self._warn_if_unbounded(X_df)
 
         # Use the reference date frozen in fit, never the transform batch's
         # max, which would make recency depend on which rows share the batch.
@@ -123,6 +139,40 @@ class RFMTransformer(TransformerMixin, BaseEstimator):
 
         return rfm_df
         
+    def _cut(self, X: Any) -> pd.DataFrame:
+        """Copy ``X``, parse ``gift_date``, and drop gifts after ``as_of``."""
+        X_df = X.copy() if hasattr(X, "columns") else pd.DataFrame(
+            X, columns=self.feature_names_in_
+        )
+        X_df['gift_date'] = pd.to_datetime(X_df['gift_date'])
+        return _apply_as_of_cutoff(
+            X_df, 'gift_date', self.as_of, "RFMTransformer", row_noun="gift"
+        )
+
+    def _warn_if_unbounded(self, X_df: pd.DataFrame) -> None:
+        """Warn when ``as_of`` is unset and gifts postdate the reference date.
+
+        Those gifts inflate ``frequency`` and ``monetary`` with money that had
+        not been given yet on the scoring date, and drive ``recency`` negative.
+        No cross-validation splitter catches it, because the leak is inside a
+        single donor's roll-up rather than across folds.
+        """
+        if self.as_of is not None or not len(X_df):
+            return
+        n_future = int((X_df['gift_date'] > self.reference_date_).sum())
+        if n_future:
+            warnings.warn(
+                f"RFMTransformer(as_of=None) is aggregating {n_future} gift "
+                f"row(s) dated after the frozen reference date "
+                f"({self.reference_date_.date()}), so frequency and monetary "
+                "include gifts that postdate the decision they describe and "
+                "recency goes negative. Set as_of to the end of your training "
+                "window, or restrict the gift table before fit. See "
+                "docs/tutorials/avoiding_temporal_data_leakage.md.",
+                UserWarning,
+                stacklevel=2,
+            )
+
     def _validate_input(self, X: Any) -> None:
         cols = X.columns if hasattr(X, "columns") else self.feature_names_in_
         required_cols = {"donor_id", "gift_date", "gift_amount"}

--- a/tests/test_rfm_transformer.py
+++ b/tests/test_rfm_transformer.py
@@ -175,3 +175,47 @@ def test_frequency_per_donor(sample_transactions):
     assert rfm[rfm['donor_id'] == 1]['frequency'].iloc[0] == 2
     assert rfm[rfm['donor_id'] == 2]['frequency'].iloc[0] == 3
     assert rfm[rfm['donor_id'] == 3]['frequency'].iloc[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# as_of cutoff: Pelletier's new-donor case
+# ---------------------------------------------------------------------------
+
+_LATE_GIFT = pd.DataFrame({
+    'donor_id': [1, 1, 1],
+    'gift_date': ['2020-01-01', '2021-01-01', '2025-01-01'],
+    'gift_amount': [100.0, 100.0, 50000.0],
+})
+
+
+def test_as_of_drops_gifts_after_the_scoring_date():
+    t = RFMTransformer(reference_date='2022-01-01', as_of='2022-01-01')
+    row = t.fit_transform(_LATE_GIFT).iloc[0]
+    assert row['frequency'] == 2
+    assert row['monetary'] == 200.0
+    assert row['recency'] == 365
+
+
+def test_as_of_none_warns_when_gifts_postdate_the_reference_date():
+    t = RFMTransformer(reference_date='2022-01-01')
+    with pytest.warns(UserWarning, match="aggregating 1 gift row"):
+        row = t.fit_transform(_LATE_GIFT).iloc[0]
+    # Unchanged behaviour, only louder: the future gift is still aggregated.
+    assert row['monetary'] == 50200.0
+    assert row['recency'] < 0
+
+
+def test_as_of_bounds_an_unset_reference_date():
+    t = RFMTransformer(as_of='2022-01-01').fit(_LATE_GIFT)
+    assert t.reference_date_ == pd.Timestamp('2021-01-01')
+
+
+def test_as_of_rejects_an_unparseable_date():
+    with pytest.raises(ValueError, match="RFMTransformer"):
+        RFMTransformer(as_of='not-a-date').fit(_LATE_GIFT)
+
+
+def test_as_of_warns_when_it_excludes_every_gift():
+    t = RFMTransformer(reference_date='2022-01-01', as_of='1999-01-01')
+    with pytest.warns(UserWarning, match="excluded every gift row"):
+        t.fit(_LATE_GIFT)


### PR DESCRIPTION
Closes #208. Closes #209.

## What this is

`RFMTransformer` is the library's gift-side roll-up, and it was the one roll-up transformer with no as-of cutoff. It froze `reference_date_` for the recency clock and then aggregated every row it was handed:

```python
gifts = pd.DataFrame({
    'donor_id': [1, 1, 1],
    'gift_date': ['2020-01-01', '2021-01-01', '2025-01-01'],
    'gift_amount': [100.0, 100.0, 50_000.0],
})
RFMTransformer(reference_date='2022-01-01').fit_transform(gifts)
#    donor_id  recency  frequency  monetary
# 0         1    -1096          3   50200.0
```

The 2025 gift is three years after the scoring date. It is in `frequency`, it is in `monetary`, and nothing warned. `EncounterTransformer` and `GratefulPatientFeaturizer` have taken `as_of` and dropped post-cutoff source rows since they were written; the gift side never did. No cross-validation splitter catches this, because the leak is inside one donor's roll-up rather than across folds.

## The change

`RFMTransformer` gains `as_of`. Gifts dated after it are dropped before any grouping, in `fit` as well as `transform`, so an unparseable value raises where the other parameters are validated and an unset `reference_date` freezes to the last gift the window allows rather than the last gift on file. Same input as above:

```
   donor_id  recency  frequency  monetary
0         1      365          2      200.0
```

Left at the default `as_of=None` the aggregation is byte-identical to before, so nobody's numbers move without opting in. It now warns rather than aggregating the future silently.

`_apply_as_of_cutoff` is reused rather than reimplemented. It gains a `row_noun` argument so the gift-side caller does not emit "excluded every encounter row" for a gift table; the two existing call sites are unchanged. The cutoff is inclusive, so the day-before rule means passing the day before, which the docstring and the tutorial both now say.

Five tests in `tests/test_rfm_transformer.py` cover the cut, the warning, the frozen reference date inside the window, the unparseable date, and an `as_of` that excludes everything.

## Where the case came from

This is not a hypothetical. Marianne Pelletier of Staupell Analytics Group, replying to the Track 2 outreach, described modelling new donors on a "lifetime giving greater than zero" variable, which for a new-donor model *is* the outcome: validation was perfect and the field was not. Her own prescription, unprompted, was roll-up variables computed to the day before the event, framed as modelling baseball, where you build the stats that were true the day before the game.

Checking her example against the code is what surfaced the gap. She granted permission on 2026-09-09 to use it with her name on it, and noted the story is already publicly associated with her from her linear-regression talks in the 2010s. Her case is the regression test, and it replaces the synthetic `total_lifetime_giving` sketch that opened the leakage tutorial.

The tutorial's claims are scoped to what the code actually does rather than to the general slogan: only the three roll-up transformers take `as_of`, and `EncounterRecencyTransformer` reads dated rows with no cutoff at all, which is filed separately as #210.

#205 stays open. It asks for the measured cost from the real-data replication, which is a different missing paragraph on the same page and is untouched here.

## Verification

```
make ci        # exit 0, 2008 passed, 8 skipped, coverage 98.25% (floor 92)
make riskcov   # exit 0
```

New lines in `_rfm.py` are fully covered; the file's three uncovered lines are the pre-existing `include_tenure` branches tracked in #150.
