### PR TITLE
fix: give EncounterRecencyTransformer the as-of cutoff too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `EncounterRecencyTransformer` gains an `as_of` parameter, the last dated
+  transformer without one. Encounters dated after it are blanked to `NaT`
+  before the features are computed, so a clinical encounter that had not
+  happened yet on the scoring date reads as a missing encounter instead of
+  producing a negative `days_since_last_encounter`. It blanks rather than
+  drops because the transformer emits one row per input row, and dropping
+  would break it inside a `Pipeline`. Left at the default `None` nothing is
+  blanked, but a post-reference-date encounter now warns instead of passing
+  silently. Closes #210.
 - `RFMTransformer` gains an `as_of` parameter. Gifts dated after it are dropped
   before the roll-up, so `frequency` and `monetary` describe only what had
   happened by the scoring date. The gift-side roll-up was the one feature

--- a/docs/tutorials/avoiding_temporal_data_leakage.md
+++ b/docs/tutorials/avoiding_temporal_data_leakage.md
@@ -20,7 +20,7 @@ The same trap catches any feature built by aggregating a source table that runs 
 
 ## The cutoff: `as_of`
 
-The three roll-up transformers, `RFMTransformer`, `EncounterTransformer` and `GratefulPatientFeaturizer`, take an `as_of` date and drop every source row dated after it *before* any roll-up is computed. `RFMTransformer` rolls a gift log up to one row per donor, so it is where Pelletier's case lands:
+Every transformer that reads a dated source table takes an `as_of` date and removes the rows dated after it *before* any feature is computed. `RFMTransformer` rolls a gift log up to one row per donor, so it is where Pelletier's case lands:
 
 ```python
 import pandas as pd
@@ -43,7 +43,7 @@ print(rfm.fit_transform(gifts))
 
 Leave `as_of` unset while the gift table runs past the reference date and the transformer warns rather than quietly aggregating the future. Without the cutoff the same donor rolls up to `frequency=3`, `monetary=50200.0` and a *negative* recency of -1096 days: the model is being told about a gift from three years after the date it is scoring.
 
-`EncounterTransformer` and `GratefulPatientFeaturizer` take the same `as_of` argument for clinical encounter tables. Transformers that read a dated table without rolling it up, such as `EncounterRecencyTransformer`, have no cutoff: restrict their input yourself.
+`EncounterTransformer` and `GratefulPatientFeaturizer` take the same `as_of` argument for clinical encounter tables. `EncounterRecencyTransformer` takes it too, with one difference: it emits one row per input row, so dropping rows would break it inside a `Pipeline`. It blanks post-cutoff encounters to `NaT` instead, and they come out as a missing encounter rather than a future one.
 
 ## The solution: fit-time snapshots
 
@@ -90,4 +90,4 @@ features_test = transformer.transform(donor_df_test)
 1. **Split first**: Split your data into training and test sets *before* passing them to a pipeline.
 2. **Use pipelines**: Wrap your transformers inside a `sklearn.pipeline.Pipeline`.
 3. **Use temporal splits**: For time-series data like fundraising, reach for `FiscalYearGroupedSplitter` (see the CV documentation) so test folds fall strictly after training folds in time.
-4. **Set `as_of`**: Pass the end of your training window to `RFMTransformer`, `EncounterTransformer` and `GratefulPatientFeaturizer`. Cross-validation cannot catch a leak that happens inside one donor's roll-up.
+4. **Set `as_of`**: Pass the end of your training window to every transformer that reads a dated table: `RFMTransformer`, `EncounterTransformer`, `GratefulPatientFeaturizer`, `EncounterRecencyTransformer`. Cross-validation cannot catch a leak that happens inside one donor's own features.

--- a/philanthropy/preprocessing/_encounter_recency.py
+++ b/philanthropy/preprocessing/_encounter_recency.py
@@ -47,6 +47,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import Tags
 from sklearn.utils.validation import check_is_fitted, validate_data
 
+from ._encounters import _parse_as_of
 from ..utils._validation import validate_fiscal_year_start
 
 _Self = TypeVar("_Self", bound="EncounterRecencyTransformer")
@@ -63,8 +64,10 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         Integer days between ``reference_date`` and the encounter date.
         ``NaN`` for missing/unparseable dates.  Always non-negative when
         ``reference_date >= encounter_date``; negative values indicate
-        future dates (rare in production) and are left as-is to allow models
-        to detect data-quality anomalies.
+        dates after the reference date, i.e. an encounter that had not
+        happened yet at the point being scored.  They are still emitted, so a
+        model can detect the data-quality anomaly, but they now warn: set
+        ``as_of`` to blank them instead.
 
     ``encounter_in_last_90d``
         Float64 0.0 / 1.0 flag: 1.0 if ``days_since_last_encounter <= 90``.
@@ -93,6 +96,17 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         clinical encounter in the training fold).  Setting an explicit
         reference date is recommended for production scoring runs to ensure
         consistency between training and inference time.
+    as_of : str, datetime-like, or None, default=None
+        Scoring-date cutoff.  Encounters dated after ``as_of`` are blanked to
+        ``NaT`` before the features are computed, so they read as missing
+        rather than as an encounter from the future: ``NaN`` days since,
+        ``0.0`` for the 90-day flag, ``NaN`` fiscal year.  The row count is
+        unchanged, so the transformer stays usable inside a
+        :class:`~sklearn.pipeline.Pipeline`.  The cutoff is inclusive, so an
+        encounter *on* ``as_of`` is kept; to roll up strictly to the day
+        before an outcome, pass that day.  Left at ``None`` nothing is
+        blanked, but a post-reference-date encounter warns instead of
+        silently producing a negative recency.
     timezone : str or None, default=None
         Optional timezone name (e.g., ``"America/Chicago"``).  When
         provided, timezone-naive datetimes in ``X`` are localised to this
@@ -157,12 +171,14 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         fiscal_year_start: int = 7,
         reference_date: Any = None,
         timezone: Optional[str] = None,
+        as_of: Any = None,
     ) -> None:
         # scikit-learn rule: __init__ ONLY assigns; no validation, no side-effects.
         self.date_col = date_col
         self.fiscal_year_start = fiscal_year_start
         self.reference_date = reference_date
         self.timezone = timezone
+        self.as_of = as_of
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -197,6 +213,22 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
             parsed = parsed.dt.tz_convert(self.timezone)
         return parsed
 
+    def _as_of_for(self, dates: pd.Series) -> Optional[pd.Timestamp]:
+        """Return ``as_of`` parsed and aligned to ``dates``' timezone, or None.
+
+        The dates carry a timezone whenever ``timezone`` is set, and the raw
+        ``as_of`` a caller passes almost never does, so the two have to be put
+        on the same clock before they can be compared at all.
+        """
+        if self.as_of is None:
+            return None
+        cutoff = _parse_as_of(self.as_of, "EncounterRecencyTransformer")
+        if dates.dt.tz is not None and cutoff.tzinfo is None:
+            return cutoff.tz_localize(self.timezone or "UTC")
+        if dates.dt.tz is None and cutoff.tzinfo is not None:
+            return cutoff.tz_convert("UTC").tz_localize(None)
+        return cutoff
+
     def _fiscal_year(self, dt: pd.Timestamp) -> int:
         """Return the fiscal year for a single Timestamp."""
         fys = int(self.fiscal_year_start)
@@ -220,6 +252,27 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
             ref_ts = ref
         else:
             ref_ts = ref
+
+        cutoff = self._as_of_for(dates)
+        if cutoff is not None:
+            # Blank rather than drop: this transformer is row-wise, so losing
+            # rows would break its use inside a Pipeline. A blanked encounter
+            # reads as missing, which every feature below already handles.
+            dates = dates.mask(dates > cutoff)
+        else:
+            n_future = int((dates > ref_ts).sum())
+            if n_future:
+                warnings.warn(
+                    f"EncounterRecencyTransformer(as_of=None) is scoring "
+                    f"{n_future} encounter(s) dated after the frozen reference "
+                    f"date ({ref_ts.date()}), so days_since_last_encounter "
+                    "goes negative for encounters that had not happened yet. "
+                    "Set as_of to the end of your scoring window to blank "
+                    "them, or restrict the input before transform. See "
+                    "docs/tutorials/avoiding_temporal_data_leakage.md.",
+                    UserWarning,
+                    stacklevel=2,
+                )
 
         try:
             delta_days = (ref_ts - dates).dt.days.astype("float64")
@@ -283,6 +336,10 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
         self : EncounterRecencyTransformer
         """
         self._validate_fiscal_year_start()
+        if self.as_of is not None:
+            # Fail here rather than at transform, where every other parameter
+            # has already been checked.
+            _parse_as_of(self.as_of, "EncounterRecencyTransformer")
 
         # Register the input schema via validate_data; allow NaN and string types.
         validate_data(self, X, dtype=None, ensure_all_finite="allow-nan", reset=True)
@@ -298,6 +355,12 @@ class EncounterRecencyTransformer(TransformerMixin, BaseEstimator):
                 for col in cols:
                     if col in X.columns:
                         parsed = self._parse_dates(X[col])
+                        cutoff = self._as_of_for(parsed)
+                        if cutoff is not None:
+                            # Otherwise an out-of-window training row would
+                            # freeze the reference date past as_of and make
+                            # every real encounter read as years stale.
+                            parsed = parsed[parsed <= cutoff]
                         mx = parsed.max()
                         if not pd.isna(mx):
                             max_dates.append(mx)

--- a/philanthropy/preprocessing/_encounters.py
+++ b/philanthropy/preprocessing/_encounters.py
@@ -59,6 +59,25 @@ _Self = TypeVar("_Self", bound="EncounterTransformer")
 # ---------------------------------------------------------------------------
 
 
+def _parse_as_of(as_of: Any, class_name: str) -> pd.Timestamp:
+    """Parse an ``as_of`` argument to a Timestamp, with one error text.
+
+    Shared by every transformer that takes ``as_of`` so the message does not
+    drift between the row-dropping callers and the row-preserving ones.
+    """
+    try:
+        cutoff = pd.Timestamp(as_of)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"{class_name}(as_of=...) must be a parseable date, got {as_of!r}."
+        ) from exc
+    if pd.isna(cutoff):
+        raise ValueError(
+            f"{class_name}(as_of=...) must be a parseable date, got {as_of!r}."
+        )
+    return cutoff
+
+
 def _apply_as_of_cutoff(
     enc: pd.DataFrame,
     discharge_col: str,
@@ -75,16 +94,7 @@ def _apply_as_of_cutoff(
     """
     if as_of is None:
         return enc
-    try:
-        cutoff = pd.Timestamp(as_of)
-    except (ValueError, TypeError) as exc:
-        raise ValueError(
-            f"{class_name}(as_of=...) must be a parseable date, got {as_of!r}."
-        ) from exc
-    if pd.isna(cutoff):
-        raise ValueError(
-            f"{class_name}(as_of=...) must be a parseable date, got {as_of!r}."
-        )
+    cutoff = _parse_as_of(as_of, class_name)
     keep = enc[discharge_col].isna() | (enc[discharge_col] <= cutoff)
     if not keep.any() and len(enc):
         warnings.warn(

--- a/tests/test_encounter_recency_as_of.py
+++ b/tests/test_encounter_recency_as_of.py
@@ -1,0 +1,62 @@
+"""``as_of`` cutoff on EncounterRecencyTransformer (issue #210).
+
+The transformer is row-wise, so the cutoff blanks post-cutoff encounters to
+``NaT`` rather than dropping their rows: dropping would change the output
+length and break the transformer inside a ``Pipeline``.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from philanthropy.preprocessing import EncounterRecencyTransformer
+
+_FUTURE = pd.DataFrame({
+    "last_encounter_date": ["2021-06-01", "2025-01-01", None],
+})
+
+
+def test_as_of_blanks_encounters_after_the_cutoff():
+    t = EncounterRecencyTransformer(reference_date="2022-01-01", as_of="2022-01-01")
+    out = t.fit_transform(_FUTURE)
+
+    assert out.shape == (3, 3)          # row count preserved
+    assert out[0, 0] == 214.0           # 2021-06-01 survives
+    assert np.isnan(out[1, 0])          # 2025-01-01 blanked
+    assert out[1, 1] == 0.0
+    assert np.isnan(out[1, 2])
+
+
+def test_as_of_is_inclusive_of_its_own_date():
+    X = pd.DataFrame({"last_encounter_date": ["2022-01-01"]})
+    t = EncounterRecencyTransformer(reference_date="2022-01-01", as_of="2022-01-01")
+    assert t.fit_transform(X)[0, 0] == 0.0
+
+
+def test_as_of_none_warns_instead_of_silently_going_negative():
+    t = EncounterRecencyTransformer(reference_date="2022-01-01")
+    with pytest.warns(UserWarning, match="scoring 1 encounter"):
+        out = t.fit_transform(_FUTURE)
+    # Unchanged behaviour, only louder.
+    assert out[1, 0] < 0
+
+
+def test_as_of_bounds_an_inferred_reference_date():
+    t = EncounterRecencyTransformer(as_of="2022-01-01").fit(_FUTURE)
+    assert t.reference_date_ == pd.Timestamp("2021-06-01")
+
+
+def test_as_of_survives_a_timezone_aware_column():
+    t = EncounterRecencyTransformer(
+        reference_date="2022-01-01",
+        timezone="America/Chicago",
+        as_of="2022-01-01",
+    )
+    out = t.fit_transform(_FUTURE)
+    assert np.isnan(out[1, 0])
+    assert out[0, 0] > 0
+
+
+def test_as_of_rejects_an_unparseable_date_in_fit():
+    with pytest.raises(ValueError, match="EncounterRecencyTransformer"):
+        EncounterRecencyTransformer(as_of="not-a-date").fit(_FUTURE)


### PR DESCRIPTION
Closes #210. Follow-up to #211, which fixed the same class of bug on the roll-up side.

## What this is

`EncounterRecencyTransformer` was the last dated transformer without an as-of cutoff. An encounter dated after the frozen `reference_date_` produced a negative `days_since_last_encounter`, and the class docstring justified that as a signal a model could learn from: "left as-is to allow models to detect data-quality anomalies."

That rationale predates the library's as-of stance. It now sits next to a tutorial that argues the opposite by name, so this PR rewrites it rather than leaving both claims standing. A negative recency is not a data-quality curiosity, it is an encounter that had not happened yet at the point being scored.

## Why it blanks instead of dropping

This is the difference from #208, and the reason #210 was filed separately rather than folded in. `RFMTransformer` and `EncounterTransformer` are roll-ups: many source rows in, one row per donor out, so dropping post-cutoff rows is free. `EncounterRecencyTransformer` emits one row per input row. Dropping rows would change the output length and break it inside a `Pipeline`.

So `as_of` blanks post-cutoff encounters to `NaT` before the features are computed. They come out as a missing encounter rather than a future one, which every feature already handles: `NaN` days since, `0.0` for the 90-day flag, `NaN` fiscal year. The row count is untouched.

```python
X = pd.DataFrame({'last_encounter_date': ['2021-06-01', '2025-01-01', None]})

EncounterRecencyTransformer(reference_date='2022-01-01').fit_transform(X)
# row 1 days_since = -1096.0, an encounter three years after the scoring date

EncounterRecencyTransformer(reference_date='2022-01-01', as_of='2022-01-01').fit_transform(X)
# row 1 days_since = NaN, in_90d = 0.0, fiscal_year = NaN; still 3 rows
```

## The rest of the change

- When `reference_date` is inferred rather than passed, out-of-window training rows are excluded before the max is taken, so `reference_date_` cannot freeze past `as_of` and make every real encounter read as years stale. Same fix as the RFM one.
- Default `as_of=None` blanks nothing, so no existing output moves. It now warns when an encounter postdates `reference_date_`, matching `RFMTransformer`'s warning rather than passing silently.
- The two `ValueError` raises inside `_apply_as_of_cutoff` move to a shared `_parse_as_of`, so all four transformers that take `as_of` raise one error text. The row-wise caller cannot use `_apply_as_of_cutoff` itself, since that helper drops rows.
- Timezone is the case that would have broken quietly: `_parse_dates` returns a tz-aware series whenever `timezone` is set and a raw `as_of` almost never carries one, so the cutoff is put on the same clock as the dates before any comparison. Covered by a test with `timezone="America/Chicago"`.
- The tutorial's scoping is updated. It previously named `EncounterRecencyTransformer` as the transformer with no cutoff; that sentence is now the explanation of why this one blanks instead of dropping.

Six tests in `tests/test_encounter_recency_as_of.py`: the blanking, row-count preservation, the inclusive boundary, the bounded inferred reference date, the tz-aware path, the warning, and the unparseable date.

## Verification

```
make ci        # exit 0, 2014 passed, 8 skipped, coverage 98.21% (floor 92)
make riskcov   # exit 0, _encounter_recency.py at 99%
```

The pre-push hook ran the full suite again before this branch was pushed.
