### PR TITLE
feat: read a Raiser's Edge gift export, and build the feature table from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- `philanthropy.ingest.raisers_edge_gifts_to_features` and
+  `read_raisers_edge_gifts`: an on-ramp from a Blackbaud Raiser's Edge gift
+  export to the donor-level feature table, alongside the existing CiviCRM and
+  UniSchema bridges. Headers are normalised from any of the three spellings the
+  product uses (desktop Export labels, the RE7 database columns, the RE NXT SKY
+  API field names) onto the canonical `contact_id` / `receive_date` /
+  `total_amount`, then the roll-up is delegated to the CiviCRM aggregator.
+  The domain knowledge it adds is the commitment-versus-payment filter: in
+  Raiser's Edge a pledge and the payments made against it are separate gift
+  records, and a recurring gift row is a template rather than money received,
+  so summing the amount column counts every committed dollar twice. The
+  commitment rows and the ledger corrections are dropped by default, matched
+  case-, space- and punctuation-insensitively so one spelling covers both the
+  desktop and NXT vocabularies, with the desktop's abbreviated matching-gift
+  types (`MG Pledge`, `MG Write Off`) named separately because they are not
+  the long forms with the spaces taken out. The excluded set is the documented
+  `exclude_gift_types` parameter, defaulting to the new
+  `DEFAULT_EXCLUDED_GIFT_TYPES`, because Raiser's Edge exports are
+  user-configured. An export with no gift-type column warns rather than
+  silently double-counting. Closes #213.
+- `philanthropy features --source {raisers_edge,civicrm} --data gifts.csv --out
+  features.csv`, a fourth CLI subcommand. This is what makes the advertised
+  no-Python path true end to end: previously `train` required `--features`
+  columns such as `total_gift_amount` that nothing in the CLI could build, so
+  "CSV in, scored CSV out" only held for someone who had already written the
+  Python that produced them. The subcommand's `--help` lists the columns it
+  emits, and the output runs through the same formula-injection neutralisation
+  as `score` because a feature table echoes donor names and emails. It does not
+  produce a label: `train --target` still needs a column the analyst defines.
 - `EncounterRecencyTransformer` gains an `as_of` parameter, the last dated
   transformer without one. Encounters dated after it are blanked to `NaT`
   before the features are computed, so a clinical encounter that had not

--- a/README.md
+++ b/README.md
@@ -151,15 +151,20 @@ scores <- model$predict_affinity_score(X)   # 0-100 affinity scores
 
 ### No Python? Use the CLI
 
-`pip install philanthropy` also puts a `philanthropy` command on your PATH. CSV in, scored CSV out, no Python file to write.
+`pip install philanthropy` also puts a `philanthropy` command on your PATH. Gift export in, scored CSV out, no Python file to write.
 
 ```bash
-philanthropy train --data gifts.csv --target is_major_donor \
-  --features total_gift_amount,years_active,event_attendance_count \
+# roll a raw Blackbaud Raiser's Edge (or CiviCRM) gift export up to one row per donor
+philanthropy features --source raisers_edge --data gifts.csv --out features.csv
+
+philanthropy train --data features.csv --target is_major_donor \
+  --features total_gift_amount,years_active,recency_days \
   --out model.joblib
 
-philanthropy score --data prospects.csv --model model.joblib --out scored.csv
+philanthropy score --data features.csv --model model.joblib --out scored.csv
 ```
+
+`features` knows that a Raiser's Edge pledge and the payments against it are separate gift records, so it does not count a committed dollar twice. It does not invent a label, though: `train --target` needs a column you define yourself, from your own definition of a major donor.
 
 `philanthropy validate` reports precision/recall/F1/ROC-AUC on a labelled CSV; point it at a holdout year, not the year you trained on. Full walkthrough: **[Use the CLI](docs/how-to/use_the_cli.md)**.
 

--- a/docs/how-to/use_the_cli.md
+++ b/docs/how-to/use_the_cli.md
@@ -1,17 +1,42 @@
 # Use the CLI
 
-Installing the package puts a `philanthropy` executable on your PATH. It is a CSV-in / CSV-out interface for analysts who are not primarily Python engineers: train a model from a labelled export, score a prospect list, and report holdout metrics, no Python file to write.
+Installing the package puts a `philanthropy` executable on your PATH. It is a CSV-in / CSV-out interface for analysts who are not primarily Python engineers: turn a raw CRM gift export into a feature table, train a model from it, score a prospect list, and report holdout metrics, no Python file to write.
 
 ```bash
 philanthropy --version
 philanthropy --help
 ```
 
-Three subcommands: `train`, `score`, `validate`.
+Four subcommands: `features`, `train`, `score`, `validate`.
+
+## Build the feature table from a CRM gift export
+
+`train` wants one row per donor with columns like `total_gift_amount` and `years_active`. A CRM gift export is one row per *gift*, so `features` does the roll-up.
+
+```bash
+philanthropy features --source raisers_edge --data gifts.csv --out features.csv
+```
+
+`--source` accepts `raisers_edge` (Blackbaud Raiser's Edge and RE NXT) or `civicrm`. `--data` takes a single CSV or a directory of them, walked recursively, which is the shape of a folder of monthly exports. Omit `--out` and the CSV goes to stdout.
+
+The output has one row per donor and these columns:
+
+`contact_id`, `constituent_email`, `first_name`, `last_name`, `total_gift_amount`, `gift_count`, `largest_gift_amount`, `first_gift_date`, `last_gift_date`, `years_active`, `recency_days`, `distinct_financial_types`
+
+Header spelling is normalised for you, so a desktop Export (`Constituent ID`, `Gift Date`, `Gift Amount`, `Gift Type`) and a SKY API pull (`constituent_id`, `date`, `amount`, `type`) both work.
+
+!!! warning "A pledge is not a payment, and `features` knows the difference"
+
+    In Raiser's Edge a pledge and the money paid against it are **separate gift records**, and a recurring gift row is a template rather than a sum ever received. Adding up the amount column double-counts every committed dollar. `features` drops the commitment rows (`Pledge`, `Matching Gift Pledge`, `Recurring Gift`) and the ledger corrections, and keeps the payments (`Pay-Cash`, `PledgePayment`, `RecurringGiftPayment`, ...). Export the **Gift Type** field or it cannot do this, and it will warn you. The excluded set is the `exclude_gift_types` parameter of `philanthropy.ingest.raisers_edge_gifts_to_features` if your site spells its types differently. For CiviCRM the equivalent traps are test-mode rows and non-`Completed` contributions, and they are dropped the same way.
+
+!!! note "`features` does not invent a label"
+
+    `train` needs a `--target` column and a gift export contains no such column. Deciding who counts as a major donor, who lapsed, or who is a planned-giving prospect is yours to define; `features` gets you the predictors, not the answer key.
+
 
 ## Train a model from a labelled CSV
 
-`train` needs the label column, the feature columns, and an output path. It writes a **bundle** (the fitted model plus the feature list, the target name, and the library versions) via `philanthropy.utils.save_model`.
+`train` needs the label column, the feature columns, and an output path. Point it at the `features.csv` from the previous step once you have added your own label column to it. It writes a **bundle** (the fitted model plus the feature list, the target name, and the library versions) via `philanthropy.utils.save_model`.
 
 ```bash
 philanthropy train \

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -54,6 +54,7 @@ Everything reachable from `philanthropy.__all__` is listed below. A symbol not l
 | `AskAmountRecommender` | `models` | The ask-ladder multipliers are a heuristic. |
 | `constituent_events_to_features`, `read_constituent_events` | `ingest` | Tracks the UniSchema `ConstituentEvent` schema, which is versioned upstream. |
 | `civicrm_contributions_to_features`, `read_civicrm_contributions` | `ingest` | Tracks CiviCRM's contribution export labels and APIv4 field names, which move with the CRM. |
+| `raisers_edge_gifts_to_features`, `read_raisers_edge_gifts`, `DEFAULT_EXCLUDED_GIFT_TYPES` | `ingest` | Tracks Raiser's Edge export labels and the RE NXT gift-type vocabulary; the excluded-type default will grow as real exports arrive. |
 | `plot_affinity_distribution`, `plot_retention_waterfall` | `visualisation` | Chart composition is presentation, not contract. |
 | `fetch_kdd98_donors` | `datasets` | Returns the raw upstream columns untyped; may gain as-of date parsing as the real-data leakage replication in #124 lands. |
 | `make_donor_panel` | `datasets` | The returned dict may gain keys (pledges, appeals, soft credits) as more of the library needs panel-shaped fixtures; existing keys and their columns will not change silently. |

--- a/philanthropy/cli.py
+++ b/philanthropy/cli.py
@@ -2,12 +2,18 @@
 philanthropy.cli
 ================
 A CSV-in / CSV-out command line for analysts who aren't primarily Python
-engineers. Three subcommands:
+engineers. Four subcommands:
 
-    philanthropy train    --data gifts.csv --target is_major_donor \\
+    philanthropy features --source raisers_edge --data gifts.csv --out features.csv
+    philanthropy train    --data features.csv --target is_major_donor \\
                           --features total_gift_amount,years_active --out model.joblib
     philanthropy score    --model model.joblib --data prospects.csv --out scores.csv
     philanthropy validate --model model.joblib --data holdout.csv --target is_major_donor
+
+`features` rolls a raw CRM gift export up into the donor-level table the models
+consume, so the path from an export to a scored CSV needs no Python. It does not
+invent a label: `train` still needs a `--target` column, and constructing one
+from your own definition of a major donor stays your job.
 
 `train` saves a self-describing bundle (the fitted model, the feature list, and
 the scikit-learn / philanthropy versions used); `score` and `validate` reuse the
@@ -18,12 +24,25 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
 
 from . import __version__
+
+# Gift-export readers `features` can front. Each name maps to a
+# (reader, aggregator) pair in _cmd_features.
+_FEATURE_SOURCES = ("civicrm", "raisers_edge")
+
+# The donor-level columns `features` emits, in order. Named here so
+# `philanthropy features --help` answers "what do I pass to --features?"
+# without a guess; tests/test_cli.py checks it against the real frame.
+_FEATURE_COLUMNS = (
+    "contact_id, constituent_email, first_name, last_name, total_gift_amount, "
+    "gift_count, largest_gift_amount, first_gift_date, last_gift_date, "
+    "years_active, recency_days, distinct_financial_types"
+)
 
 _MODEL_CHOICES = (
     "DonorPropensityModel",
@@ -175,6 +194,42 @@ def _cmd_validate(args: argparse.Namespace) -> None:
     print(f"roc_auc   {roc_auc_score(y, y_proba):.3f}")
 
 
+def _cmd_features(args: argparse.Namespace) -> None:
+    from . import ingest
+    from .utils._validation import ensure_local_path
+
+    read: Callable[..., pd.DataFrame]
+    to_features: Callable[..., pd.DataFrame]
+    if args.source == "raisers_edge":
+        read = ingest.read_raisers_edge_gifts
+        to_features = ingest.raisers_edge_gifts_to_features
+    else:
+        read = ingest.read_civicrm_contributions
+        to_features = ingest.civicrm_contributions_to_features
+
+    ensure_local_path(args.data, "data")
+    try:
+        gifts = read(args.data)
+    except FileNotFoundError:
+        raise SystemExit(f"Data file not found: {args.data}")
+    try:
+        features = to_features(gifts)
+    except KeyError as exc:
+        # The aggregators name the missing export fields; that message is the
+        # whole answer, so surface it instead of a traceback.
+        raise SystemExit(str(exc.args[0] if exc.args else exc))
+
+    # reset_index first: contact_id is the index, and _neutralise_csv_injection
+    # only walks columns, so an index left in place would skip the escaping and
+    # then be written to the CSV anyway by to_csv(index=True).
+    out = _neutralise_csv_injection(features.reset_index())
+    if args.out:
+        out.to_csv(args.out, index=False)
+        print(f"Wrote {len(out)} donor rows to {args.out}")
+    else:
+        out.to_csv(sys.stdout, index=False)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="philanthropy",
@@ -184,6 +239,29 @@ def _build_parser() -> argparse.ArgumentParser:
         "--version", action="version", version=f"philanthropy {__version__}"
     )
     sub = parser.add_subparsers(dest="command", required=True)
+
+    features = sub.add_parser(
+        "features",
+        help="Roll a CRM gift export up into the donor-level feature table.",
+        description=(
+            "Aggregate a raw CRM gift export into the one-row-per-donor table "
+            "the models consume, then feed that to `train` and `score`. "
+            "Emitted columns, in order: " + _FEATURE_COLUMNS + ". Commitment "
+            "rows (pledges, recurring gift templates) are dropped for "
+            "raisers_edge, and test-mode and non-Completed rows for civicrm, "
+            "so a committed dollar is not counted twice. No label is produced: "
+            "`train --target` needs a column you define yourself."
+        ),
+    )
+    features.add_argument(
+        "--source", required=True, choices=_FEATURE_SOURCES,
+        help="which CRM the export came from",
+    )
+    features.add_argument(
+        "--data", required=True, help="gift export CSV, or a directory of them"
+    )
+    features.add_argument("--out", default=None, help="output CSV path (default: stdout)")
+    features.set_defaults(func=_cmd_features)
 
     train = sub.add_parser("train", help="Train a model from a labelled CSV and save it.")
     train.add_argument("--data", required=True, help="path to a labelled CSV")

--- a/philanthropy/ingest/__init__.py
+++ b/philanthropy/ingest/__init__.py
@@ -11,6 +11,11 @@ one-row-per-donor feature frame the estimators consume.
 CiviCRM: ``read_civicrm_contributions`` loads a contribution export CSV;
 ``civicrm_contributions_to_features`` aggregates it the same way, dropping
 test-mode and non-``Completed`` rows first.
+
+Raiser's Edge: ``read_raisers_edge_gifts`` loads a Blackbaud gift export CSV;
+``raisers_edge_gifts_to_features`` aggregates it, dropping the commitment rows
+(pledges, matching gift pledges, recurring gift templates) first so a pledged
+dollar is not counted both as the promise and as the payments against it.
 """
 
 from ._civicrm import (
@@ -21,10 +26,18 @@ from ._constituent_events import (
     constituent_events_to_features,
     read_constituent_events,
 )
+from ._raisers_edge import (
+    DEFAULT_EXCLUDED_GIFT_TYPES,
+    raisers_edge_gifts_to_features,
+    read_raisers_edge_gifts,
+)
 
 __all__ = [
+    "DEFAULT_EXCLUDED_GIFT_TYPES",
     "civicrm_contributions_to_features",
     "constituent_events_to_features",
+    "raisers_edge_gifts_to_features",
     "read_civicrm_contributions",
     "read_constituent_events",
+    "read_raisers_edge_gifts",
 ]

--- a/philanthropy/ingest/_civicrm.py
+++ b/philanthropy/ingest/_civicrm.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import re
 import warnings
 from pathlib import Path
-from typing import Iterable, Mapping, Optional, Sequence, Union
+from typing import Callable, Iterable, Mapping, Optional, Sequence, Union
 
 import pandas as pd
 
@@ -338,10 +338,12 @@ def _canonical(header: str) -> str:
     return _HEADER_ALIASES.get(key, key)
 
 
-def _normalise_headers(df: pd.DataFrame) -> pd.DataFrame:
+def _normalise_headers(
+    df: pd.DataFrame, canonical: Callable[[str], str] = _canonical
+) -> pd.DataFrame:
     if df.empty and df.columns.empty:
         return df
-    out = df.rename(columns={c: _canonical(c) for c in df.columns})
+    out = df.rename(columns={c: canonical(c) for c in df.columns})
     # A wide export can carry the same field twice ("Amount" and "Total
     # Amount"), which would collapse to two identically named columns and make
     # df["total_amount"] a DataFrame. Keep the first.

--- a/philanthropy/ingest/_raisers_edge.py
+++ b/philanthropy/ingest/_raisers_edge.py
@@ -1,0 +1,292 @@
+"""
+philanthropy.ingest._raisers_edge
+=================================
+Bridge from a Blackbaud Raiser's Edge gift export to a PhilanthroPy
+donor-level feature table.
+
+`The Raiser's Edge <https://www.blackbaud.com>`_ is the CRM most academic
+medical centres and large nonprofits run their advancement shop on, and a gift
+export out of it is the file a prospect researcher actually has to hand.  Like
+CiviCRM it surfaces the same table under more than one spelling: the desktop
+Export module writes human labels (``Constituent ID``, ``Gift Date``, ``Gift
+Amount``, ``Gift Type``), the underlying database columns are terser
+(``CONSTIT_ID``, ``DTE``, ``TYPE``), and the RE NXT SKY API returns
+``constituent_id`` / ``date`` / ``amount`` / ``type``.  All three are accepted
+here and normalised onto the canonical ``contact_id`` / ``receive_date`` /
+``total_amount`` names.
+
+:func:`read_raisers_edge_gifts` loads the CSV(s);
+:func:`raisers_edge_gifts_to_features` drops the commitment rows and hands the
+remaining payments to :func:`~philanthropy.ingest.civicrm_contributions_to_features`,
+which already knows how to roll a gift log up into the one-row-per-donor frame
+the estimators consume.
+
+**The trap this exists to prevent is commitment versus payment.** In Raiser's
+Edge a pledge and the money paid against it are *separate gift records*.  The
+Gift Records Guide is explicit: "When you receive a pledge payment from the
+constituent, you must create a separate gift record for the pledge payment and
+apply the payment toward the pledge to reduce the balance."  A ``Pledge`` row's
+``Pledge amt`` is "the total amount the constituent agreed to give", so summing
+gift amounts naively counts every pledged dollar twice, once as the promise and
+again as each payment.  A ``Recurring Gift`` row is worse: it is a template, and
+its ``Amount`` is "the amount the constituent wants to pay at a recurring
+interval", not a sum ever received.  Both are excluded by default; the payment
+rows they generate (``Pay-Cash``, ``PledgePayment``, ``RecurringGiftPayment``,
+``MG Pay-Cash``, ...) are kept, because those are the money.
+
+Raiser's Edge exports are user-configured, so the excluded set is a documented
+default parameter rather than a constant: see
+:data:`DEFAULT_EXCLUDED_GIFT_TYPES`.
+
+Sources: Blackbaud, *The Raiser's Edge Gift Records Guide*
+(https://help.blackbaud.com/docs/0/assets/guides/re/gifts.pdf), "Understanding
+Gift Types" and "Gift Types and Subtypes"; Blackbaud Knowledgebase article
+46484, "What are gift types?".
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from pathlib import Path
+from typing import Iterable, Mapping, Optional, Sequence, Union
+
+import pandas as pd
+
+from ._civicrm import (
+    _NON_ALNUM,
+    _REQUIRED,
+    _canonical,
+    _empty_feature_frame,
+    _normalise_headers,
+    _to_frame,
+    civicrm_contributions_to_features,
+    read_civicrm_contributions,
+)
+
+__all__ = [
+    "DEFAULT_EXCLUDED_GIFT_TYPES",
+    "raisers_edge_gifts_to_features",
+    "read_raisers_edge_gifts",
+]
+
+#: Gift types excluded from the roll-up by default: the commitment rows, whose
+#: amount is a promise rather than money received, and the ledger corrections,
+#: which are not gifts at all. Matching ignores case, spacing and punctuation,
+#: so one spelling here covers every dialect the same type is written in:
+#: ``"Recurring Gift"`` also matches the SKY API's ``RecurringGift`` and a
+#: hand-renamed ``recurring_gift``. Payment rows are *not* in this set and are
+#: what the features are built from.
+DEFAULT_EXCLUDED_GIFT_TYPES = (
+    "Pledge",
+    "Matching Gift Pledge",
+    # The desktop abbreviates the matching-gift types, and the abbreviation is
+    # not punctuation away from the long form, so it needs its own entry. It is
+    # the commitment half of the "MG Pay-Cash" the payment set keeps.
+    "MG Pledge",
+    "Recurring Gift",
+    "Amendment",
+    "Adjustment",
+    "General Ledger Reversal",
+    "Write Off",
+    "Pledge Write Off",
+    "Matching Gift Write Off",
+    "MG Write Off",
+)
+
+# Raiser's Edge header normalisation, applied before the CiviCRM bridge's own.
+# Case and punctuation are already collapsed ("Gift Date" -> gift_date), so this
+# maps only the residue onto the canonical names. Anything absent here falls
+# through to the CiviCRM canonicaliser, which already handles the labels the two
+# systems happen to share ("Amount", "Email", "First Name").
+_HEADER_ALIASES = {
+    # Constituent key: export label, RE7 database column, SKY API field.
+    "constituent_id": "contact_id",
+    "constituent_system_record_id": "contact_id",
+    "constituent_lookup_id": "contact_id",
+    "constit_id": "contact_id",
+    "donor_id": "contact_id",
+    # Date. The guide renames this field per gift type: a Pledge row carries
+    # "Pledged on" where a Cash row carries "Gift date".
+    "gift_date": "receive_date",
+    "pledged_on": "receive_date",
+    "date": "receive_date",
+    "dte": "receive_date",
+    # Amount, renamed per gift type the same way: "Pledge amt" on a Pledge,
+    # "Value" on a Gift-in-Kind or Stock/Property.
+    "gift_amount": "total_amount",
+    "pledge_amt": "total_amount",
+    "pledge_amount": "total_amount",
+    "value": "total_amount",
+    # Gift type: the column this module exists to read.
+    "type": "gift_type",
+    "gift_type_name": "gift_type",
+    # Fund is the Raiser's Edge analogue of CiviCRM's Financial Type: the GL
+    # classification a gift is designated to. It feeds distinct_financial_types.
+    "fund": "financial_type",
+    "fund_description": "financial_type",
+    "fund_id": "financial_type",
+}
+
+# Gift-type matching key: strip everything but letters and digits so
+# "Recurring Gift", "RecurringGift" and "recurring_gift" collapse to one value.
+_NON_ALNUM_ALL = re.compile(r"[^a-z0-9]+")
+
+
+def raisers_edge_gifts_to_features(
+    gifts: Union[Iterable[Mapping], pd.DataFrame],
+    *,
+    reference_date: Optional[Union[str, pd.Timestamp]] = None,
+    exclude_gift_types: Optional[Sequence[str]] = DEFAULT_EXCLUDED_GIFT_TYPES,
+) -> pd.DataFrame:
+    """Aggregate a Raiser's Edge gift export into donor-level features.
+
+    Commitment rows (pledges, matching gift pledges, recurring gift templates)
+    and ledger corrections are dropped first, then the surviving payment rows
+    are handed to :func:`civicrm_contributions_to_features`, which produces the
+    donor frame. Raiser's Edge has no contribution-status column, so no status
+    filter is applied.
+
+    Parameters
+    ----------
+    gifts : iterable of mapping, or DataFrame
+        Raiser's Edge gift rows, under the desktop export labels
+        (``Constituent ID``, ``Gift Date``, ``Gift Amount``, ``Gift Type``), the
+        RE7 database columns (``CONSTIT_ID``, ``DTE``, ``TYPE``) or the RE NXT
+        SKY API field names (``constituent_id``, ``date``, ``amount``,
+        ``type``). ``contact_id``, ``receive_date`` and ``total_amount`` are
+        required after normalisation; ``gift_type``, ``fund``, ``email``,
+        ``first_name`` and ``last_name`` are used when present.
+    reference_date : str or datetime-like, optional
+        Anchor for the recency features. If ``None``, the latest gift date in
+        the batch is used, which keeps the aggregation free of "now" leakage.
+    exclude_gift_types : sequence of str or None, default=:data:`DEFAULT_EXCLUDED_GIFT_TYPES`
+        Gift types to drop before aggregating, matched against ``gift_type``
+        ignoring case, spacing and punctuation. ``None`` or an empty sequence
+        disables the filter and sums **every** row, which double-counts pledged
+        dollars. Rows whose gift type is blank are kept either way: an unlabelled
+        row cannot be shown to be a commitment.
+
+    Returns
+    -------
+    features : pandas.DataFrame
+        One row per donor, indexed by ``contact_id``, with the same columns
+        :func:`civicrm_contributions_to_features` emits.
+        ``distinct_financial_types`` counts distinct Funds here.
+
+    Raises
+    ------
+    KeyError
+        If ``contact_id``, ``receive_date`` or ``total_amount`` is absent after
+        normalisation.
+
+    Warns
+    -----
+    UserWarning
+        If ``exclude_gift_types`` was requested but the export carries no gift
+        type column. Silently summing pledges together with their payments is
+        exactly the error this bridge exists to prevent, so it is worth a
+        warning rather than a quiet wrong total.
+
+    Notes
+    -----
+    A Raiser's Edge export of *split* gifts writes one row per split, all
+    sharing the gift's system record id, and their amounts are meant to be
+    summed. Nothing here deduplicates on a gift id for that reason, so
+    concatenating two exports that overlap in time will double-count the
+    overlap; export disjoint date ranges.
+
+    Examples
+    --------
+    >>> rows = [
+    ...     {"Constituent ID": "88", "Gift Date": "2025-01-10",
+    ...      "Gift Amount": "1200.00", "Gift Type": "Pledge"},
+    ...     {"Constituent ID": "88", "Gift Date": "2025-02-10",
+    ...      "Gift Amount": "100.00", "Gift Type": "Pay-Cash"},
+    ...     {"Constituent ID": "88", "Gift Date": "2025-03-10",
+    ...      "Gift Amount": "100.00", "Gift Type": "Pay-Cash"},
+    ... ]
+    >>> feats = raisers_edge_gifts_to_features(rows)
+    >>> float(feats.loc["88", "total_gift_amount"])  # not 1400.0
+    200.0
+    >>> int(feats.loc["88", "gift_count"])
+    2
+    """
+    df = _normalise_headers(_to_frame(gifts), _canonical_raisers_edge)
+    if df.empty:
+        return _empty_feature_frame()
+
+    missing = [col for col in _REQUIRED if col not in df.columns]
+    if missing:
+        raise KeyError(
+            f"Raiser's Edge gift export is missing {missing}. Export the "
+            f"'Constituent ID', 'Gift Date' and 'Gift Amount' fields (SKY API: "
+            f"constituent_id, date, amount); got {sorted(df.columns)}."
+        )
+
+    if exclude_gift_types:
+        if "gift_type" in df.columns:
+            unwanted = {_gift_type_key(t) for t in exclude_gift_types}
+            keys = df["gift_type"].map(_gift_type_key)
+            df = df[~keys.isin(unwanted)]
+        else:
+            warnings.warn(
+                f"Raiser's Edge gift export has no gift type column, so "
+                f"exclude_gift_types={tuple(exclude_gift_types)!r} could not be "
+                f"applied: pledges and recurring gift templates (if any) are "
+                f"summed alongside the payments made against them, which counts "
+                f"every committed dollar twice. Add the 'Gift Type' field to the "
+                f"export.",
+                stacklevel=2,
+            )
+
+    if df.empty:
+        return _empty_feature_frame()
+    return civicrm_contributions_to_features(
+        df, reference_date=reference_date, statuses=None
+    )
+
+
+def read_raisers_edge_gifts(path: Union[str, Path]) -> pd.DataFrame:
+    """Read Raiser's Edge gift export CSV(s) into one frame.
+
+    Accepts a single ``.csv`` or a directory of them, walked recursively and
+    concatenated in sorted relative-path order; symlinks are not followed. Every
+    column is read as text and nothing is filtered: **commitment rows are still
+    present**, and it is :func:`raisers_edge_gifts_to_features` that drops them.
+
+    Reading a gift export is CRM-agnostic once the headers are normalised, so
+    this delegates to :func:`read_civicrm_contributions` rather than repeating
+    its BOM handling and path hardening. Raiser's Edge headers are normalised on
+    the way into :func:`raisers_edge_gifts_to_features`, not here.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        CSV file, or a directory of them.
+
+    Returns
+    -------
+    gifts : pandas.DataFrame
+        The export as written, with text values.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    """
+    return read_civicrm_contributions(path)
+
+
+# --------------------------------------------------------------------------- #
+# Internals
+# --------------------------------------------------------------------------- #
+def _canonical_raisers_edge(header: str) -> str:
+    key = _NON_ALNUM.sub("_", str(header).strip().lower()).strip("_")
+    return _HEADER_ALIASES.get(key) or _canonical(header)
+
+
+def _gift_type_key(value: object) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    return _NON_ALNUM_ALL.sub("", str(value).strip().lower())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,3 +143,127 @@ def test_cli_missing_feature_column_lists_available(tmp_path):
     with pytest.raises(SystemExit, match=r"not found in .*Available:"):
         main(["train", "--data", str(data), "--target", "is_major_donor",
               "--features", "nope_col", "--out", str(tmp_path / "m.joblib")])
+
+
+# --------------------------------------------------------------------------- #
+# `features`: gift export in, donor-level feature table out
+# --------------------------------------------------------------------------- #
+_RE_HEADER = "Constituent ID,Gift Date,Gift Amount,Gift Type,Fund,Email\n"
+
+
+def _make_gift_export(tmp_path, name="gifts.csv", n_donors=60):
+    rows = [_RE_HEADER]
+    for i in range(n_donors):
+        rows.append(f"{i},2025-01-10,{1000 + i * 10}.00,Pledge,Annual Fund,d{i}@amc.edu\n")
+        rows.append(f"{i},2025-02-10,{100 + i}.00,Pay-Cash,Annual Fund,d{i}@amc.edu\n")
+        rows.append(f"{i},2025-03-10,{50 + i}.00,Pay-Cash,Annual Fund,d{i}@amc.edu\n")
+    path = tmp_path / name
+    path.write_text("".join(rows))
+    return path
+
+
+def test_cli_features_raisers_edge_drops_the_pledge_rows(tmp_path, capsys):
+    data = _make_gift_export(tmp_path, n_donors=3)
+    out_path = tmp_path / "features.csv"
+    main(["features", "--source", "raisers_edge", "--data", str(data),
+          "--out", str(out_path)])
+    feats = pd.read_csv(out_path)
+    assert len(feats) == 3
+    # Donor 0: 100 + 50 in payments, and not the 1000 pledge on top.
+    row = feats.loc[feats["contact_id"] == 0].iloc[0]
+    assert row["total_gift_amount"] == 150.0
+    assert row["gift_count"] == 2
+    assert "Wrote 3 donor rows" in capsys.readouterr().out
+
+
+def test_cli_features_writes_contact_id_as_a_column(tmp_path):
+    data = _make_gift_export(tmp_path, n_donors=2)
+    out_path = tmp_path / "features.csv"
+    main(["features", "--source", "raisers_edge", "--data", str(data),
+          "--out", str(out_path)])
+    assert list(pd.read_csv(out_path).columns)[0] == "contact_id"
+
+
+def test_cli_features_writes_to_stdout_by_default(tmp_path, capsys):
+    data = _make_gift_export(tmp_path, n_donors=2)
+    main(["features", "--source", "raisers_edge", "--data", str(data)])
+    out = capsys.readouterr().out
+    assert out.startswith("contact_id,")
+    assert len(out.strip().splitlines()) == 3
+
+
+def test_cli_features_civicrm_source(tmp_path):
+    path = tmp_path / "contributions.csv"
+    path.write_text(
+        "Contact ID,Contribution Date,Total Amount,Contribution Status\n"
+        "101,2025-01-15,250.00,Completed\n"
+        "101,2025-02-15,99.00,Failed\n"
+    )
+    out_path = tmp_path / "features.csv"
+    main(["features", "--source", "civicrm", "--data", str(path),
+          "--out", str(out_path)])
+    feats = pd.read_csv(out_path)
+    assert feats.iloc[0]["total_gift_amount"] == 250.0
+
+
+def test_cli_features_neutralises_csv_injection(tmp_path):
+    path = tmp_path / "gifts.csv"
+    path.write_text(_RE_HEADER + "1,2025-01-10,100.00,Cash,Annual Fund,=cmd|calc\n")
+    out_path = tmp_path / "features.csv"
+    main(["features", "--source", "raisers_edge", "--data", str(path),
+          "--out", str(out_path)])
+    assert "'=cmd|calc" in out_path.read_text()
+
+
+def test_cli_features_missing_export_field_exits_with_the_field_names(tmp_path, capsys):
+    path = tmp_path / "gifts.csv"
+    path.write_text("Constituent ID,Gift Type\n1,Cash\n")
+    with pytest.raises(SystemExit) as excinfo:
+        main(["features", "--source", "raisers_edge", "--data", str(path)])
+    assert "Gift Date" in str(excinfo.value)
+
+
+def test_cli_features_missing_data_file_exits(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["features", "--source", "raisers_edge",
+              "--data", str(tmp_path / "nope.csv")])
+
+
+def test_cli_features_help_lists_the_columns_it_actually_emits(tmp_path):
+    """The help text is what tells an analyst what to pass to `train
+    --features`, so it must not drift from the real frame."""
+    from philanthropy.cli import _FEATURE_COLUMNS
+
+    data = _make_gift_export(tmp_path, n_donors=2)
+    out_path = tmp_path / "features.csv"
+    main(["features", "--source", "raisers_edge", "--data", str(data),
+          "--out", str(out_path)])
+    emitted = list(pd.read_csv(out_path).columns)
+    assert [c.strip() for c in _FEATURE_COLUMNS.split(",")] == emitted
+
+
+def test_cli_features_then_train_then_score(tmp_path, capsys):
+    """The path the CLI advertises, end to end: a raw Raiser's Edge gift export
+    in, a scored CSV out, no Python. The label is still the analyst's: `train`
+    needs a --target column that no gift export contains."""
+    data = _make_gift_export(tmp_path, n_donors=80)
+    feature_path = tmp_path / "features.csv"
+    main(["features", "--source", "raisers_edge", "--data", str(data),
+          "--out", str(feature_path)])
+
+    labelled = pd.read_csv(feature_path)
+    labelled["is_major_donor"] = (labelled["total_gift_amount"] > 200).astype(int)
+    labelled_path = tmp_path / "labelled.csv"
+    labelled.to_csv(labelled_path, index=False)
+
+    model_path = tmp_path / "m.joblib"
+    main(["train", "--data", str(labelled_path), "--target", "is_major_donor",
+          "--features", "total_gift_amount,gift_count,recency_days",
+          "--out", str(model_path)])
+
+    scores_path = tmp_path / "scores.csv"
+    main(["score", "--model", str(model_path), "--data", str(feature_path),
+          "--out", str(scores_path)])
+    scored = pd.read_csv(scores_path)
+    assert "score" in scored.columns
+    assert len(scored) == 80

--- a/tests/test_raisers_edge.py
+++ b/tests/test_raisers_edge.py
@@ -1,0 +1,352 @@
+"""
+tests/test_raisers_edge.py
+Tests for the philanthropy.ingest Blackbaud Raiser's Edge gift bridge.
+
+The point of the module is one filter: in Raiser's Edge a pledge and the
+payments against it are separate gift records, so a naive sum counts every
+committed dollar twice. Most of what follows checks that the commitment rows
+leave and the payment rows stay, in each spelling the two Raiser's Edge
+generations write them in.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from philanthropy.ingest import (
+    DEFAULT_EXCLUDED_GIFT_TYPES,
+    raisers_edge_gifts_to_features,
+    read_raisers_edge_gifts,
+)
+from philanthropy.ingest._civicrm import _FEATURE_DTYPES
+
+# Header labels as the Raiser's Edge desktop Export module writes them.
+_HEADER = (
+    "Constituent ID,Gift Date,Gift Amount,Gift Type,Fund,Email,"
+    "First Name,Last Name"
+)
+
+
+def _row(contact, date, amount, gift_type, *, fund="Annual Fund",
+         email="", first="", last=""):
+    return f"{contact},{date},{amount},{gift_type},{fund},{email},{first},{last}"
+
+
+def _export(*rows):
+    return "\n".join((_HEADER,) + rows) + "\n"
+
+
+@pytest.fixture
+def gifts():
+    """One donor with a $1,200 pledge paid in two $100 instalments, and one
+    with a recurring gift template plus one payment against it."""
+    return [
+        {"Constituent ID": "88", "Gift Date": "2025-01-10",
+         "Gift Amount": "1200.00", "Gift Type": "Pledge", "Fund": "Annual Fund",
+         "Email": "ada@amc.edu", "First Name": "Ada", "Last Name": "Lovelace"},
+        {"Constituent ID": "88", "Gift Date": "2025-02-10",
+         "Gift Amount": "100.00", "Gift Type": "Pay-Cash", "Fund": "Annual Fund",
+         "Email": "ada@amc.edu", "First Name": "Ada", "Last Name": "Lovelace"},
+        {"Constituent ID": "88", "Gift Date": "2025-03-10",
+         "Gift Amount": "100.00", "Gift Type": "Pay-Cash", "Fund": "Annual Fund",
+         "Email": "ada@amc.edu", "First Name": "Ada", "Last Name": "Lovelace"},
+        {"Constituent ID": "91", "Gift Date": "2025-02-01",
+         "Gift Amount": "50.00", "Gift Type": "Recurring Gift", "Fund": "Research",
+         "Email": "grace@amc.edu", "First Name": "Grace", "Last Name": "Hopper"},
+        {"Constituent ID": "91", "Gift Date": "2025-03-01",
+         "Gift Amount": "50.00", "Gift Type": "Recurring Gift Pay-Cash",
+         "Fund": "Capital", "Email": "grace@amc.edu",
+         "First Name": "Grace", "Last Name": "Hopper"},
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# The commitment-versus-payment filter
+# --------------------------------------------------------------------------- #
+def test_pledge_is_excluded_and_its_payments_are_not(gifts):
+    feats = raisers_edge_gifts_to_features(gifts)
+    # 1200 (the promise) + 100 + 100 would be 1400; only the payments count.
+    assert float(feats.loc["88", "total_gift_amount"]) == 200.0
+    assert int(feats.loc["88", "gift_count"]) == 2
+
+
+def test_recurring_gift_template_is_excluded_and_its_payment_is_not(gifts):
+    feats = raisers_edge_gifts_to_features(gifts)
+    assert float(feats.loc["91", "total_gift_amount"]) == 50.0
+    assert int(feats.loc["91", "gift_count"]) == 1
+
+
+@pytest.mark.parametrize(
+    "gift_type",
+    ["Pledge", "Matching Gift Pledge", "MG Pledge", "Recurring Gift",
+     "Amendment", "Adjustment", "General Ledger Reversal", "Write Off",
+     "Pledge Write Off", "Matching Gift Write Off", "MG Write Off"],
+)
+def test_every_default_excluded_type_is_dropped(gift_type):
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "500.00", "Gift Type": gift_type},
+            {"Constituent ID": "1", "Gift Date": "2025-01-02",
+             "Gift Amount": "10.00", "Gift Type": "Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+@pytest.mark.parametrize(
+    "gift_type",
+    ["Cash", "Pay-Cash", "MG Pay-Cash", "Recurring Gift Pay-Cash",
+     "Gift-in-Kind", "Stock/Property", "Other", "Donation", "PledgePayment",
+     "MatchingGiftPayment", "RecurringGiftPayment", "SoldStock", "PlannedGift"],
+)
+def test_payment_and_outright_types_are_kept(gift_type):
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "10.00", "Gift Type": gift_type}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+@pytest.mark.parametrize(
+    "gift_type",
+    ["MatchingGiftPledge", "RecurringGift", "PledgeWriteOff",
+     "MatchingGiftWriteOff", "GeneralLedgerReversal", "recurring_gift",
+     "RECURRING GIFT", "  Pledge  "],
+)
+def test_exclusion_matching_ignores_case_spacing_and_punctuation(gift_type):
+    """The RE NXT SKY API writes RecurringGift where the desktop writes
+    Recurring Gift; the default set names one spelling and matches both."""
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "500.00", "Gift Type": gift_type},
+            {"Constituent ID": "1", "Gift Date": "2025-01-02",
+             "Gift Amount": "10.00", "Gift Type": "Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_a_pay_type_is_not_matched_by_its_commitment_prefix():
+    """'Recurring Gift Pay-Cash' must not be swept up by 'Recurring Gift'."""
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "25.00", "Gift Type": "Recurring Gift Pay-Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 25.0
+
+
+def test_blank_gift_type_is_kept():
+    """An unlabelled row cannot be shown to be a commitment, so it stays."""
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "10.00", "Gift Type": ""},
+            {"Constituent ID": "1", "Gift Date": "2025-01-02",
+             "Gift Amount": "5.00", "Gift Type": None}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 15.0
+    assert int(feats.loc["1", "gift_count"]) == 2
+
+
+def test_custom_exclude_set_replaces_the_default(gifts):
+    feats = raisers_edge_gifts_to_features(gifts, exclude_gift_types=("Pay-Cash",))
+    # Pledge is no longer excluded; the two Pay-Cash payments are.
+    assert float(feats.loc["88", "total_gift_amount"]) == 1200.0
+
+
+def test_exclude_none_counts_every_row(gifts):
+    feats = raisers_edge_gifts_to_features(gifts, exclude_gift_types=None)
+    assert float(feats.loc["88", "total_gift_amount"]) == 1400.0
+    assert int(feats.loc["88", "gift_count"]) == 3
+
+
+def test_empty_exclude_sequence_counts_every_row(gifts):
+    feats = raisers_edge_gifts_to_features(gifts, exclude_gift_types=())
+    assert float(feats.loc["88", "total_gift_amount"]) == 1400.0
+
+
+def test_missing_gift_type_column_warns():
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "10.00"}]
+    with pytest.warns(UserWarning, match="no gift type column"):
+        feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+def test_exclude_none_does_not_warn_about_a_missing_gift_type_column():
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "10.00"}]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        raisers_edge_gifts_to_features(rows, exclude_gift_types=None)
+
+
+def test_default_excluded_set_is_documented_and_non_empty():
+    assert "Pledge" in DEFAULT_EXCLUDED_GIFT_TYPES
+    assert "Recurring Gift" in DEFAULT_EXCLUDED_GIFT_TYPES
+
+
+def test_the_abbreviated_matching_gift_commitment_is_excluded_too():
+    """'MG Pledge' is not 'Matching Gift Pledge' with the punctuation removed,
+    so collapsing case and punctuation does not make one match the other. The
+    desktop writes the abbreviated form, and it is the commitment half of the
+    'MG Pay-Cash' the payment set keeps."""
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "500.00", "Gift Type": "MG Pledge"},
+            {"Constituent ID": "1", "Gift Date": "2025-01-02",
+             "Gift Amount": "10.00", "Gift Type": "MG Pay-Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 10.0
+
+
+# --------------------------------------------------------------------------- #
+# Header dialects
+# --------------------------------------------------------------------------- #
+def test_sky_api_field_names_are_accepted():
+    """RE NXT's SKY API returns constituent_id / date / amount / type."""
+    rows = [{"constituent_id": "7", "date": "2025-05-01", "amount": "300.00",
+             "type": "Donation"},
+            {"constituent_id": "7", "date": "2025-05-02", "amount": "999.00",
+             "type": "Pledge"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["7", "total_gift_amount"]) == 300.0
+
+
+def test_re7_database_column_names_are_accepted():
+    """The RE7 tables spell them CONSTIT_ID / DTE / AMOUNT / TYPE."""
+    rows = [{"CONSTIT_ID": "7", "DTE": "2025-05-01", "AMOUNT": "300.00",
+             "TYPE": "Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["7", "total_gift_amount"]) == 300.0
+
+
+def test_export_labels_and_sky_names_agree(gifts):
+    sky = [
+        {"constituent_id": g["Constituent ID"], "date": g["Gift Date"],
+         "amount": g["Gift Amount"], "type": g["Gift Type"],
+         "fund": g["Fund"], "email": g["Email"],
+         "first_name": g["First Name"], "last_name": g["Last Name"]}
+        for g in gifts
+    ]
+    pd.testing.assert_frame_equal(
+        raisers_edge_gifts_to_features(gifts),
+        raisers_edge_gifts_to_features(sky),
+    )
+
+
+@pytest.mark.parametrize("amount_label", ["Gift Amount", "Amount", "Pledge amt", "Value"])
+def test_every_amount_label_the_guide_names_is_accepted(amount_label):
+    """The Gift Records Guide renames the amount field per gift type: Amount on
+    a Cash gift, Pledge amt on a Pledge, Value on a Gift-in-Kind."""
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             amount_label: "42.00", "Gift Type": "Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 42.0
+
+
+@pytest.mark.parametrize("date_label", ["Gift Date", "Pledged on", "date"])
+def test_every_date_label_the_guide_names_is_accepted(date_label):
+    rows = [{"Constituent ID": "1", date_label: "2025-01-01",
+             "Gift Amount": "42.00", "Gift Type": "Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert feats.loc["1", "last_gift_date"] == pd.Timestamp("2025-01-01")
+
+
+def test_currency_formatted_amounts_parse():
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "$1,250.00", "Gift Type": "Cash"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert float(feats.loc["1", "total_gift_amount"]) == 1250.0
+
+
+# --------------------------------------------------------------------------- #
+# Schema, identity and recency
+# --------------------------------------------------------------------------- #
+def test_schema_and_dtypes(gifts):
+    feats = raisers_edge_gifts_to_features(gifts)
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+    assert feats.index.name == "contact_id"
+
+
+def test_fund_feeds_distinct_financial_types(gifts):
+    feats = raisers_edge_gifts_to_features(gifts, exclude_gift_types=None)
+    # Donor 91's two rows sit on Research and Capital.
+    assert int(feats.loc["91", "distinct_financial_types"]) == 2
+    assert int(feats.loc["88", "distinct_financial_types"]) == 1
+
+
+def test_carries_identity_fields(gifts):
+    feats = raisers_edge_gifts_to_features(gifts)
+    assert feats.loc["88", "constituent_email"] == "ada@amc.edu"
+    assert feats.loc["88", "first_name"] == "Ada"
+    assert feats.loc["88", "last_name"] == "Lovelace"
+
+
+def test_reference_date_shifts_recency(gifts):
+    feats = raisers_edge_gifts_to_features(gifts, reference_date="2025-12-31")
+    assert int(feats.loc["88", "recency_days"]) == 296
+
+
+def test_recency_anchors_on_the_batch_by_default(gifts):
+    feats = raisers_edge_gifts_to_features(gifts)
+    # Latest surviving gift is donor 88's 2025-03-10 payment.
+    assert int(feats.loc["88", "recency_days"]) == 0
+
+
+def test_empty_input_returns_a_typed_empty_frame():
+    feats = raisers_edge_gifts_to_features([])
+    assert feats.empty
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+
+
+def test_every_row_filtered_out_returns_a_typed_empty_frame():
+    rows = [{"Constituent ID": "1", "Gift Date": "2025-01-01",
+             "Gift Amount": "500.00", "Gift Type": "Pledge"}]
+    feats = raisers_edge_gifts_to_features(rows)
+    assert feats.empty
+    assert list(feats.columns) == list(_FEATURE_DTYPES)
+    assert feats.index.name == "contact_id"
+
+
+def test_missing_required_column_names_the_raisers_edge_fields():
+    rows = [{"Constituent ID": "1", "Gift Type": "Cash"}]
+    with pytest.raises(KeyError) as excinfo:
+        raisers_edge_gifts_to_features(rows)
+    message = str(excinfo.value)
+    assert "Raiser's Edge" in message
+    assert "Gift Date" in message
+    # A CiviCRM-worded error here would read as "you used the wrong reader".
+    assert "CiviCRM" not in message
+
+
+# --------------------------------------------------------------------------- #
+# Reading
+# --------------------------------------------------------------------------- #
+def test_read_single_csv(tmp_path):
+    path = tmp_path / "gifts.csv"
+    path.write_text(_export(_row("88", "2025-01-10", "1200.00", "Pledge"),
+                            _row("88", "2025-02-10", "100.00", "Pay-Cash")))
+    raw = read_raisers_edge_gifts(path)
+    assert len(raw) == 2
+    # Reading is lossless: the pledge row is still there.
+    feats = raisers_edge_gifts_to_features(raw)
+    assert float(feats.loc["88", "total_gift_amount"]) == 100.0
+
+
+def test_read_directory_concatenates(tmp_path):
+    (tmp_path / "jan.csv").write_text(
+        _export(_row("88", "2025-01-10", "100.00", "Cash"))
+    )
+    (tmp_path / "feb.csv").write_text(
+        _export(_row("88", "2025-02-10", "250.00", "Cash"))
+    )
+    feats = raisers_edge_gifts_to_features(read_raisers_edge_gifts(tmp_path))
+    assert float(feats.loc["88", "total_gift_amount"]) == 350.0
+
+
+def test_read_missing_path_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_raisers_edge_gifts(tmp_path / "nope.csv")
+
+
+def test_numeric_looking_constituent_ids_stay_text(tmp_path):
+    """dtype=str on the read keeps 0088 from becoming 88, and a blank in the
+    column from turning the whole thing into floats."""
+    path = tmp_path / "gifts.csv"
+    path.write_text(_export(_row("0088", "2025-01-10", "100.00", "Cash"),
+                            _row("", "2025-01-11", "50.00", "Cash")))
+    feats = raisers_edge_gifts_to_features(read_raisers_edge_gifts(path))
+    assert list(feats.index) == ["0088"]


### PR DESCRIPTION
Closes #213.

`philanthropy.ingest` shipped readers for CiviCRM and UniSchema, in a field where Blackbaud is dominant, and the CLI could not build a feature table at all. `train` requires `--features` and indexes straight into columns like `total_gift_amount` that nothing in the package produced from a raw export, so "CSV in, scored CSV out, no Python" only held for someone who had already written the Python that made them. This adds the reader and the missing subcommand.

## The trap this exists to prevent

In Raiser's Edge a pledge and the money paid against it are **separate gift records**. The Gift Records Guide says so directly: "When you receive a pledge payment from the constituent, you must create a separate gift record for the pledge payment and apply the payment toward the pledge to reduce the balance." A `Pledge` row's amount is "the total amount the constituent agreed to give", so adding up the amount column counts every pledged dollar twice, once as the promise and again as each payment. A `Recurring Gift` row is worse: it is a template, and its amount is "the amount the constituent wants to pay at a recurring interval", never a sum received.

`raisers_edge_gifts_to_features` drops the commitment rows and the ledger corrections by default and keeps the payments (`Pay-Cash`, `PledgePayment`, `RecurringGiftPayment`, `MG Pay-Cash`, ...), because those are the money. The gift-type vocabulary is taken from Blackbaud's published Gift Records Guide and knowledgebase, not from memory.

Matching ignores case, spacing and punctuation, so one entry covers both the desktop and the RE NXT spelling of the same type. The desktop's abbreviated matching-gift types are named separately, because `MG Pledge` is not `Matching Gift Pledge` with the spaces taken out and would otherwise have leaked into the total. Exports are user-configured, so the excluded set is the documented `exclude_gift_types` parameter (default `DEFAULT_EXCLUDED_GIFT_TYPES`), not a constant. An export with no gift-type column warns instead of silently double-counting.

## What is reused rather than rewritten

The aggregation already existed. Headers are normalised from any of the three spellings Raiser's Edge uses (desktop Export labels, the RE7 database columns, the RE NXT SKY API field names) onto `contact_id` / `receive_date` / `total_amount`, then the roll-up is delegated to `civicrm_contributions_to_features` with `statuses=None`, since Raiser's Edge has no contribution-status column. `read_raisers_edge_gifts` delegates its I/O to `read_civicrm_contributions` rather than repeating the recursive walk, symlink skip and BOM handling. **No shared `_aggregate.py` is extracted**; that waits for NPSP as a second caller. The one thing duplicated is the required-column check, and only so its `KeyError` is worded in Raiser's Edge terms: a CiviCRM-worded error here reads as "you used the wrong reader".

`_civicrm._normalise_headers` gains an optional canonicaliser argument. That is the whole change to the existing module.

## The `features` subcommand

```bash
philanthropy features --source raisers_edge --data gifts.csv --out features.csv
```

`--source` also accepts `civicrm`. Two details that are deliberate rather than incidental:

- It reads through the ingest reader, not `cli._read_csv`, because the ingest reader is `dtype=str`. Pandas' default types turn a Constituent ID column with one blank in it into floats, and the donor key into `"101.0"`.
- The frame is `reset_index()`ed **before** `_neutralise_csv_injection`, because that function walks columns and would have skipped the index, which `to_csv` then writes anyway. That also puts `contact_id` in the output so `score` carries it through.

`--help` lists the emitted columns, and a test checks that list against the real frame so it cannot drift.

## What is still not true after this

`train` needs a `--target` and a gift export carries no label. The honest claim is **gift export in, feature table out, then train and score**; constructing the label stays the analyst's job. The README and the CLI how-to say that rather than implying otherwise, so the announcement copy has something accurate to quote.

Two stated limitations, both in the code:

- The alias map and the excluded-type default come from public documentation, not from a real export. Both widen without an API change. Confirming them against one redacted real export is the follow-up, and is the on-topic reason to ask in Apra's Tools and Resources community.
- Nothing deduplicates on a gift id. A split-gift export writes one row per split sharing that id and their amounts are meant to be summed, so deduplicating would delete money. The docstring says so, and says to export disjoint date ranges instead.

## Verification

- `make ci`: 2089 passed, 8 skipped, total coverage 98.25%.
- `make riskcov`: passes the 93% floor. `philanthropy/ingest/_raisers_edge.py` 100%, `philanthropy/cli.py` 99%.
- 66 tests in `tests/test_raisers_edge.py`, mirroring `tests/test_civicrm.py` in depth: every default-excluded type dropped, every payment and outright type kept, the abbreviated matching-gift case, `Recurring Gift Pay-Cash` surviving its own commitment prefix, each header dialect, every amount and date label the guide names, the missing-column warning, the typed empty frame, and the reader on a file and a directory.
- 9 new tests in `tests/test_cli.py`, including the end-to-end `features` → label → `train` → `score` path.
- Pre-push hook ran the full suite.

## Sources

- Blackbaud, *The Raiser's Edge Gift Records Guide*, "Understanding Gift Types" and "Gift Types and Subtypes": <https://help.blackbaud.com/docs/0/assets/guides/re/gifts.pdf>
- Blackbaud Knowledgebase 46484, "What are gift types?", and 41510, "How to run the Gift Detail and Summary Report", for the `Pay-` and `MG Pay-` variants.

## Not for merge yet

plan.md's weekly-commit item measures ISO week 37 at 13 commits by author date against a ~12 cap, and its standing consequence is to merge nothing of the maintainer's own before 2026-09-14. Opening this, not merging it.
