### PR TITLE
Document Windows-specific gaps in the local test/CI gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   lifetime-giving-greater-than-zero variable, where the feature was the
   outcome. It replaces the synthetic `total_lifetime_giving` sketch and gains a
   runnable `as_of` walkthrough of the same failure. Closes #209.
-
+- `CONTRIBUTING.md` and `docs/how-to/develop_and_test.md` now document the
+  Windows-specific gaps in the local test/CI gate: `make ci`/`make riskcov`
+  require `make`, which is not available in PowerShell by default, and
+  `sh scripts/install_hooks.sh` requires Git Bash. Testing confirmed the
+  installed pre-push hook does not fire when pushing from plain PowerShell.
+  Closes #195.
+  
 ### Fixed
 - `EncounterRecencyTransformer` no longer catches timezone conversion errors
   and retries with `tz_localize` after parsing with `utc=True`. The retry was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `sh scripts/install_hooks.sh` requires Git Bash. Testing confirmed the
   installed pre-push hook does not fire when pushing from plain PowerShell.
   Closes #195.
-  
+
 ### Fixed
 - `EncounterRecencyTransformer` no longer catches timezone conversion errors
   and retries with `tz_localize` after parsing with `utc=True`. The retry was

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,9 +131,15 @@ equivalent commands directly instead of `make ci` / `make riskcov`:
 python -m flake8 philanthropy tests examples
 python -m mypy philanthropy
 python -m pytest philanthropy --doctest-modules -q --no-cov
+python -m pytest tests/ --collect-only -q
 python -m coverage run -m pytest tests/ -q
-python -m coverage report --fail-under=92
+python -m coverage report
 ```
+
+`coverage report` reads the overall floor from `[tool.coverage.report]` in
+`pyproject.toml`, so the bare command enforces exactly what CI does. Do not
+pass `--fail-under` here: the number is defined once and copying it into a
+second place is how the two drift apart.
 
 For the risk-tier coverage floor, see the `RISK_TIER`/`RISK_FLOOR` values
 in the `Makefile` and run:
@@ -144,8 +150,8 @@ python -m coverage report --include='<RISK_TIER from Makefile>' --fail-under=<RI
 
 If `pytest --cov=...` (via `pytest-cov`) raises
 `ImportError: cannot load module more than once per process` on numpy
-import, use `coverage run -m pytest` followed by `coverage report` instead
-— same result, different import path.
+import, use `coverage run -m pytest` followed by `coverage report` instead.
+Same result, different import path.
 
 The `sh scripts/install_hooks.sh` pre-push hook requires Git Bash to
 install, and does not fire when pushing from plain PowerShell. Run it via

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ git switch -c my-change         # never work on main
 pip install -e ".[dev]"          # editable install so the working tree is what's tested
 sh scripts/install_hooks.sh      # pre-push hook: runs the suite before every push
 ```
+> **Windows contributors:** `make` is not available in PowerShell by default,
+> so `make ci` and `make riskcov` below will not run as written. See
+> [Testing on Windows](#testing-on-windows) for the equivalent commands.
+> `sh scripts/install_hooks.sh` also requires Git Bash; the installed
+> pre-push hook does **not** fire when pushing from plain PowerShell, only
+> from a POSIX-compatible shell (confirmed by testing).
 
 Install editable: a non-editable copy in site-packages will shadow your edits
 under pytest and silently run stale code.
@@ -116,6 +122,34 @@ Before committing a new test file, always verify:
 python -m pytest <new_test_file.py> --collect-only -q
 # Must show: X tests collected, 0 errors
 ```
+## Testing on Windows
+
+`make` and `sh` are not available in PowerShell by default. Run the
+equivalent commands directly instead of `make ci` / `make riskcov`:
+
+```powershell
+python -m flake8 philanthropy tests examples
+python -m mypy philanthropy
+python -m pytest philanthropy --doctest-modules -q --no-cov
+python -m coverage run -m pytest tests/ -q
+python -m coverage report --fail-under=92
+```
+
+For the risk-tier coverage floor, see the `RISK_TIER`/`RISK_FLOOR` values
+in the `Makefile` and run:
+
+```powershell
+python -m coverage report --include='<RISK_TIER from Makefile>' --fail-under=<RISK_FLOOR from Makefile>
+```
+
+If `pytest --cov=...` (via `pytest-cov`) raises
+`ImportError: cannot load module more than once per process` on numpy
+import, use `coverage run -m pytest` followed by `coverage report` instead
+— same result, different import path.
+
+The `sh scripts/install_hooks.sh` pre-push hook requires Git Bash to
+install, and does not fire when pushing from plain PowerShell. Run it via
+Git Bash, or run the commands above manually before every push.
 
 ## Versioning & deprecation
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,8 +29,8 @@ contribution. Code, docs, tests, and review all count.
   timestamps empty-frame path and the `distinct_source_systems` default when
   `sourceSystem` is absent.
 - [@AsavariCharati](https://github.com/AsavariCharati): documented the Windows-specific
-  gaps in the local test/CI gate — `make`/`sh` unavailable by default, and the
-  pre-push hook not firing from plain PowerShell — in `CONTRIBUTING.md` and
+  gaps in the local test/CI gate (`make`/`sh` unavailable by default, and the
+  pre-push hook not firing from plain PowerShell) in `CONTRIBUTING.md` and
   `docs/how-to/develop_and_test.md` (closes
   [#195](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/195)).
 - [@shubhrai23](https://github.com/shubhrai23): added missing docstrings to

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,6 +28,11 @@ contribution. Code, docs, tests, and review all count.
   two untested guards in `constituent_events_to_features`: the all-unparseable-
   timestamps empty-frame path and the `distinct_source_systems` default when
   `sourceSystem` is absent.
+- [@AsavariCharati](https://github.com/AsavariCharati): documented the Windows-specific
+  gaps in the local test/CI gate — `make`/`sh` unavailable by default, and the
+  pre-push hook not firing from plain PowerShell — in `CONTRIBUTING.md` and
+  `docs/how-to/develop_and_test.md` (closes
+  [#195](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/195)).
 - [@shubhrai23](https://github.com/shubhrai23): added missing docstrings to
   `UpliftTLearner` and `cli.main`, `Raises` sections to five metrics functions,
   and fallback-path coverage for `predict_affinity_score`

--- a/docs/how-to/develop_and_test.md
+++ b/docs/how-to/develop_and_test.md
@@ -11,6 +11,10 @@ Install the development dependencies:
 ```bash
 pip install -e ".[dev]"
 ```
+> **Windows:** the commands below (`pytest ...`) work as written. If
+> `pytest tests/ --cov=philanthropy` raises `ImportError: cannot load
+> module more than once per process`, run `coverage run -m pytest tests/`
+> followed by `coverage report` instead.
 
 ## Running Tests Locally
 


### PR DESCRIPTION
Resolves #195

Documents the Windows-specific gaps in the local test/CI workflow, reported firsthand across #74 and #188:

- `CONTRIBUTING.md`: adds a callout after Setup noting `make`/`sh` aren't available in PowerShell by default, plus a new "Testing on Windows" section with the equivalent `python -m` commands for `make ci`, and a pointer to the Makefile for the risk-tier coverage floor (not copied verbatim, per the issue's instruction).
- `docs/how-to/develop_and_test.md`: adds a short Windows note after Prerequisites covering the `pytest-cov` / numpy `ImportError` workaround.

Also confirmed by testing (not assumed): the installed pre-push hook does **not** fire when pushing from plain PowerShell -only from a POSIX-compatible shell (verified with a throwaway branch/commit/push, since removed).

No code changes, so the CHANGELOG credit-guard doesn't fire on this PR, but added an entry under [Unreleased] → Changed and a line in CONTRIBUTORS.md anyway, per the issue's explicit instruction.

Note: while running the full suite locally to verify nothing broke, found 11 pre-existing failures unrelated to this change - `urlparse` on Windows reads a `C:\...` path's drive letter as a URL scheme (`'c'`), so `ensure_local_path` rejects every valid local Windows path. Out of scope here; happy to open a separate issue for it.