### PR TITLE
fix(validation): accept Windows drive paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   runnable `as_of` walkthrough of the same failure. Closes #209.
 
 ### Fixed
+- `ensure_local_path` now accepts absolute Windows drive-letter paths such as
+  `C:\\data\\gifts.csv` without weakening rejection of network URLs. Closes #217.
 - `EncounterRecencyTransformer` no longer catches timezone conversion errors
   and retries with `tz_localize` after parsing with `utc=True`. The retry was
   unreachable for valid timezone inputs and replaced the useful

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,9 @@ contribution. Code, docs, tests, and review all count.
 
 ## Contributors
 
+- **Leyn.cx** ([@laichouchi](https://github.com/laichouchi)): fixed Windows
+  drive-letter paths being rejected as URI schemes (closes #217).
+
 - **Chris Chen** ([@fuleinist](https://github.com/fuleinist)): replaced a
   tautological doctest in `FiscalYearGroupedSplitter` with one that can actually
   fail, and added the missing no-leakage test for the default `gap_years=0`

--- a/philanthropy/utils/_validation.py
+++ b/philanthropy/utils/_validation.py
@@ -72,6 +72,11 @@ def ensure_local_path(path: _PathT, param_name: str = "path") -> _PathT:
     from urllib.parse import urlparse
 
     scheme = urlparse(str(path)).scheme
+    # urlparse treats the drive letter in an absolute Windows path such as
+    # C:\\data\\gifts.csv as a one-character URI scheme. It is still a local
+    # path, even when this check runs on a non-Windows host.
+    if len(scheme) == 1 and scheme.isalpha():
+        scheme = ""
     if scheme not in _LOCAL_SCHEMES:
         raise ValueError(
             f"`{param_name}` must be a local file path (no network reads), "

--- a/tests/test_no_network.py
+++ b/tests/test_no_network.py
@@ -135,6 +135,13 @@ def test_cli_data_path_rejects_remote_scheme(no_network):
         _read_csv("gs://bucket/prospects.csv")
 
 
+def test_windows_drive_letter_path_is_local():
+    from philanthropy.utils._validation import ensure_local_path
+
+    for path in (r"C:\data\gifts.csv", r"z:\data\gifts.csv"):
+        assert ensure_local_path(path) == path
+
+
 def test_local_paths_still_load_under_the_guard(no_network, tmp_path):
     from philanthropy.cli import _read_csv
 


### PR DESCRIPTION
## Summary
- treat one-character URL schemes as Windows drive letters in ensure_local_path
- keep rejecting real network schemes such as https, s3, gs, and gcs
- add regression coverage for uppercase and lowercase drive letters
- document the fix and add the contributor entry

Closes #217

## Validation
- make ci
- make riskcov
- 2,070 tests passed, 29 skipped
- total coverage: 98.22%
- risk-tier coverage: 98%