### PR TITLE
Add PlannedGiving array transform regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   the input carried column names. It now falls back to `x0`, `x1`, ... for an
   array fit, matching what `WealthScreeningImputer` and `WealthScreeningImputerKNN`
   already did. Closes #157.
+- Added regression coverage for `PlannedGivingSignalTransformer` when transforming a NumPy array after fitting on a DataFrame.
 
 ### Added
 - `tests/test_public_api_contract.py` gains two contracts over every public

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,6 +83,9 @@ contribution. Code, docs, tests, and review all count.
   added DataFrame and array-fit tests so `MovesManagementClassifier.feature_names_in_`
   is exercised rather than only assigned (closes
   [#200](https://github.com/PhilanthroPy-Project/PhilanthroPy/issues/200)).
+- [@Dikshant2965](https://github.com/Dikshant2965): added regression coverage for
+  `PlannedGivingSignalTransformer` when transforming a NumPy array after fitting
+  on a DataFrame (closes #154).
 
 ## Getting listed
 

--- a/tests/test_planned_giving.py
+++ b/tests/test_planned_giving.py
@@ -39,6 +39,22 @@ class TestPlannedGivingSignalTransformer:
         result = t.transform(X)
         assert result.shape == (3, 4)
 
+
+    def test_transform_accepts_array_after_dataframe_fit(self):
+        """DataFrame fit must support NumPy-array transform."""
+        t = PlannedGivingSignalTransformer()
+        X = _make_df(
+            donor_age=[70.0, 60.0, 80.0],
+            years_active=[15.0, 5.0, 12.0],
+            planned_gift_inclination=[0.8, 0.3, 0.5],
+        )
+
+        t.fit(X)
+        expected = t.transform(X)
+        result = t.transform(X.to_numpy())
+
+        np.testing.assert_allclose(result, expected)
+
     def test_legacy_age_flag_threshold_boundary(self):
         """age=64 → 0, age=65 → 1 (default threshold=65)."""
         t = PlannedGivingSignalTransformer(age_threshold=65)


### PR DESCRIPTION
## Summary
- Add regression coverage for transforming a NumPy array after fitting `PlannedGivingSignalTransformer` on a DataFrame.
- Update the changelog and contributors list.

## Testing
- `python -m pytest tests/test_planned_giving.py -q`
- Result: 19 passed, 1 warning

Closes #154
